### PR TITLE
Adding custom class to datagrid column

### DIFF
--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -144,7 +144,9 @@ define(function(require) {
 				$.each(data.data, function (index, row) {
 					rowHTML += '<tr>';
 					$.each(self.columns, function (index, column) {
-						rowHTML += '<td>' + row[column.property] + '</td>';
+						rowHTML += '<td';
+						if (column.class) rowHTML += ' class="' + column.class + '"';
+						rowHTML += '>' + row[column.property] + '</td>';
 					});
 					rowHTML += '</tr>';
 				});


### PR DESCRIPTION
I came across a problem that required a column to have special styling. The cell needed a static width and relative positioning. The current datagrid does not support custom classes for columns so I was forced to use some hack to get the desired results. Maybe other people will find this helpful!  
