### PR TITLE
spinner.js - stopped changing the initial value if it is defined already

### DIFF
--- a/src/spinner.js
+++ b/src/spinner.js
@@ -55,7 +55,9 @@ define(function(require) {
 		constructor: Spinner,
 
 		render: function () {
-			this.$input.val(this.options.value);
+			if(!this.$input.val()){
+				this.$input.val(this.options.value);
+			}
 			this.$input.attr('maxlength',(this.options.max + '').split('').length);
 		},
 


### PR DESCRIPTION
Stopped changing the initial value to '1' or custom if the HTML element's "value" is set and not empty
