### PR TITLE
Checkbox styling changes to fix IE bug.

### DIFF
--- a/src/less/checkbox.less
+++ b/src/less/checkbox.less
@@ -10,7 +10,9 @@
 
 .checkbox-custom {
 	input[type=checkbox] {
-		display: none;
+	/* IE cannot fire events if display none or visibility hidden */
+	position: relative;
+	top: -99999px;
 	}
 
 	i {


### PR DESCRIPTION
Issue #145. IE can't fire events if the checkbox is hidden or display none, so just move it off the page.
