### PR TITLE
Cleanup select resize method

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -8,162 +8,166 @@
 
 define(function(require) {
 
-    var $ = require('jquery');
+	var $ = require('jquery');
 	require('./util');
 
-    // SELECT CONSTRUCTOR AND PROTOTYPE
+	// SELECT CONSTRUCTOR AND PROTOTYPE
 
-    var Select = function (element, options) {
-        this.$element = $(element);
-        this.options = $.extend({}, $.fn.select.defaults, options);
-        this.$element.on('click', 'a', $.proxy(this.itemclicked, this));
-        this.$button = this.$element.find('.btn');
-        this.$label = this.$element.find('.dropdown-label');
-        this.setDefaultSelection();
+	var Select = function (element, options) {
+		this.$element = $(element);
+		this.options = $.extend({}, $.fn.select.defaults, options);
+		this.$element.on('click', 'a', $.proxy(this.itemclicked, this));
+		this.$button = this.$element.find('.btn');
+		this.$label = this.$element.find('.dropdown-label');
+		this.setDefaultSelection();
 
-        if (options.resize === 'auto') {
-            this.resize();
-        }
-    };
+		if (options.resize === 'auto') {
+			this.resize();
+		}
+	};
 
-    Select.prototype = {
+	Select.prototype = {
 
-        constructor: Select,
+		constructor: Select,
 
-        itemclicked: function (e) {
-            this.$selectedItem = $(e.target).parent();
-            this.$label.text(this.$selectedItem.text());
+		itemclicked: function (e) {
+			this.$selectedItem = $(e.target).parent();
+			this.$label.text(this.$selectedItem.text());
 
-            // pass object including text and any data-attributes
-            // to onchange event
-            var data = this.selectedItem();
+			// pass object including text and any data-attributes
+			// to onchange event
+			var data = this.selectedItem();
 
-            // trigger changed event
-            this.$element.trigger('changed', data);
+			// trigger changed event
+			this.$element.trigger('changed', data);
 
-            e.preventDefault();
-        },
+			e.preventDefault();
+		},
 
-        resize: function() {
-            var el = $('#selectTextSize')[0];
+		resize: function() {
+			var el = $('#selectTextSize');
+			var cleanup = false;
+			var newWidth = 0;
+			var width = 0;
 
-            // create element if it doesn't exist
-            // used to calculate the length of the longest string
-            if(!el) {
-                $('<div/>').attr({id:'selectTextSize'}).appendTo('body');
-            }
+			// create element if it doesn't exist
+			// used to calculate the length of the longest string
+			if(!el.length) {
+				el = $('<div/>').attr({id:'selectTextSize', style:'visibility:hidden'});
+				el.appendTo('body');
+				cleanup = true;
+			}
 
-            var width = 0;
-            var newWidth = 0;
+			// iterate through each item to find longest string
+			this.$element.find('a').each(function () {
+				var $this = $(this);
+				var txt = $this.text();
+				el.text(txt);
+				newWidth = el.outerWidth();
+				if(newWidth > width) {
+					width = newWidth;
+				}
+			});
+			if (cleanup === true) {
+				el.remove();
+			}
 
-            // iterate through each item to find longest string
-            this.$element.find('a').each(function () {
-                var $this = $(this);
-                var txt = $this.text();
-                var $txtSize = $('#selectTextSize');
-                $txtSize.text(txt);
-                newWidth = $txtSize.outerWidth();
-                if(newWidth > width) {
-                    width = newWidth;
-                }
-            });
+			this.$label.width(width);
+		},
 
-            this.$label.width(width);
-        },
+		selectedItem: function() {
+			var txt = this.$selectedItem.text();
+			return $.extend({ text: txt }, this.$selectedItem.data());
+		},
 
-        selectedItem: function() {
-            var txt = this.$selectedItem.text();
-            return $.extend({ text: txt }, this.$selectedItem.data());
-        },
+		selectByText: function(text) {
+			var selector = 'li a:fuelTextExactCI(' + text + ')';
+			this.selectBySelector(selector);
+		},
 
-        selectByText: function(text) {
-            var selector = 'li a:fuelTextExactCI(' + text + ')';
-            this.selectBySelector(selector);
-        },
+		selectByValue: function(value) {
+			var selector = 'li[data-value="' + value + '"]';
+			this.selectBySelector(selector);
+		},
 
-        selectByValue: function(value) {
-            var selector = 'li[data-value="' + value + '"]';
-            this.selectBySelector(selector);
-        },
+		selectByIndex: function(index) {
+			// zero-based index
+			var selector = 'li:eq(' + index + ')';
+			this.selectBySelector(selector);
+		},
 
-        selectByIndex: function(index) {
-            // zero-based index
-            var selector = 'li:eq(' + index + ')';
-            this.selectBySelector(selector);
-        },
+		selectBySelector: function(selector) {
+			var item = this.$element.find(selector);
 
-        selectBySelector: function(selector) {
-            var item = this.$element.find(selector);
+			this.$selectedItem = item;
+			this.$label.text(this.$selectedItem.text());
+		},
 
-            this.$selectedItem = item;
-            this.$label.text(this.$selectedItem.text());
-        },
+		setDefaultSelection: function() {
+			var selector = 'li[data-selected=true]:first';
+			var item = this.$element.find(selector);
+			if(item.length === 0) {
+				// select first item
+				this.selectByIndex(0);
+			}
+			else {
+				// select by data-attribute
+				this.selectBySelector(selector);
+				item.removeData('selected');
+				item.removeAttr('data-selected');
+			}
+		},
 
-        setDefaultSelection: function() {
-            var selector = 'li[data-selected=true]:first';
-            var item = this.$element.find(selector);
-            if(item.length === 0) {
-                // select first item
-                this.selectByIndex(0);
-            }
-            else {
-                // select by data-attribute
-                this.selectBySelector(selector);
-                item.removeData('selected');
-                item.removeAttr('data-selected');
-            }
-        },
+		enable: function() {
+			this.$button.removeClass('disabled');
+		},
 
-        enable: function() {
-            this.$button.removeClass('disabled');
-        },
+		disable: function() {
+			this.$button.addClass('disabled');
+		}
 
-        disable: function() {
-            this.$button.addClass('disabled');
-        }
-
-    };
-
-
-    // SELECT PLUGIN DEFINITION
-
-    $.fn.select = function (option,value) {
-        var methodReturn;
-
-        var $set = this.each(function () {
-            var $this = $(this);
-            var data = $this.data('select');
-            var options = typeof option === 'object' && option;
-
-            if (!data) $this.data('select', (data = new Select(this, options)));
-            if (typeof option === 'string') methodReturn = data[option](value);
-        });
-
-        return (methodReturn === undefined) ? $set : methodReturn;
-    };
-
-    $.fn.select.defaults = {};
-
-    $.fn.select.Constructor = Select;
+	};
 
 
-    // SELECT DATA-API
+	// SELECT PLUGIN DEFINITION
 
-    $(function () {
+	$.fn.select = function (option,value) {
+		var methodReturn;
 
-        $(window).on('load', function () {
-            $('.select').each(function () {
-                var $this = $(this);
-                if ($this.data('select')) return;
-                $this.select($this.data());
-            });
-        });
+		var $set = this.each(function () {
+			var $this = $(this);
+			var data = $this.data('select');
+			var options = typeof option === 'object' && option;
 
-        $('body').on('mousedown.select.data-api', '.select', function (e) {
-            var $this = $(this);
-            if ($this.data('select')) return;
-            $this.select($this.data());
-        });
-    });
+			if (!data) $this.data('select', (data = new Select(this, options)));
+			if (typeof option === 'string') methodReturn = data[option](value);
+		});
+
+		return (methodReturn === undefined) ? $set : methodReturn;
+	};
+
+	$.fn.select.defaults = {};
+
+	$.fn.select.Constructor = Select;
+
+
+	// SELECT DATA-API
+
+	$(function () {
+
+		$(window).on('load', function () {
+			$('.select').each(function () {
+				var $this = $(this);
+				if ($this.data('select')) return;
+				$this.select($this.data());
+			});
+		});
+
+		$('body').on('mousedown.select.data-api', '.select', function (e) {
+			var $this = $(this);
+			if ($this.data('select')) return;
+			$this.select($this.data());
+		});
+	});
 
 });


### PR DESCRIPTION
Noticed this is generating an extra element w/o cleaning it up.

If no select element present for sizing, make one and clean it up afterwards.
Save a few vars by reusing the original jquery element.
Save some memory in a loop.
