### PR TITLE
Remove Window onLoad Event

### DIFF
--- a/src/radio.js
+++ b/src/radio.js
@@ -96,13 +96,11 @@ define(function (require) {
 	// RADIO DATA-API
 
 	$(function () {
-		$(window).on('load', function () {
-			//$('i.radio').each(function () {
-			$('.radio-custom > input[type=radio]').each(function () {
-				var $this = $(this);
-				if ($this.data('radio')) return;
-				$this.radio($this.data());
-			});
+		//$('i.radio').each(function () {
+		$('.radio-custom > input[type=radio]').each(function () {
+			var $this = $(this);
+			if ($this.data('radio')) return;
+			$this.radio($this.data());
 		});
 	});
 


### PR DESCRIPTION
It is redundant while nested inside an anonymous function. In my case, the window had already loaded so the event never got fired. I also don't see the point in waiting for the window to load as document ready should be sufficient.
