### PR TITLE
Remove Window onLoad Event

### DIFF
--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -96,13 +96,11 @@ define(function (require) {
 	// CHECKBOX DATA-API
 
 	$(function () {
-		$(window).on('load', function () {
-			//$('i.checkbox').each(function () {
-			$('.checkbox-custom > input[type=checkbox]').each(function () {
-				var $this = $(this);
-				if ($this.data('checkbox')) return;
-				$this.checkbox($this.data());
-			});
+		//$('i.checkbox').each(function () {
+		$('.checkbox-custom > input[type=checkbox]').each(function () {
+			var $this = $(this);
+			if ($this.data('checkbox')) return;
+			$this.checkbox($this.data());
 		});
 	});
 


### PR DESCRIPTION
It is redundant while nested inside an anonymous function. In my case, the window had already loaded so the event never got fired. I also don't see the point in waiting for the window to load as document ready should be sufficient.
