### PR TITLE
issue-170

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+.project

--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -166,7 +166,7 @@ define(function(require) {
 					rowHTML += '</tr>';
 				});
 
-				if (!rowHTML) rowHTML = self.placeholderRowHTML('0 ' + self.options.itemsText);
+				if (!rowHTML) rowHTML = self.placeholderRowHTML(self.options.noDataFoundHTML);
 
 				self.$tbody.html(rowHTML);
 				self.stretchHeight();
@@ -328,7 +328,8 @@ define(function(require) {
 		dataOptions: { pageIndex: 0, pageSize: 10 },
 		loadingHTML: '<div class="progress progress-striped active" style="width:50%;margin:auto;"><div class="bar" style="width:100%;"></div></div>',
 		itemsText: 'items',
-		itemText: 'item'
+		itemText: 'item',
+		noDataFoundHTML: '0 items'
 	};
 
 	$.fn.datagrid.Constructor = Datagrid;

--- a/test/datagrid-test.js
+++ b/test/datagrid-test.js
@@ -78,6 +78,23 @@ require(['jquery', 'fuelux/datagrid'], function($) {
 		var $activityrow = $datagrid.find('tbody tr');
 		equal($activityrow.length, 1, 'activity row was rendered');
 	});
+	
+	asyncTest("should handle data source with zero records - custom no records text", function () {
+        var $datagrid = $(datagridHTML).datagrid({ dataSource: emptyDataSource, noDataFoundHTML: '<div style="background-color:blue;">NO DATA FOUND</div>' }).on('loaded', function () {
+
+            var $datarows = $datagrid.find('tbody tr');
+            equal($datarows.length, 1, 'row for status was rendered');
+
+            var $testcell = $datarows.eq(0).find('td');
+            equal($testcell.html(), '<div style="background-color:blue;">NO DATA FOUND</div>', 'empty status is displayed');
+            equal($testcell.attr('colspan'), '2', 'empty status spans all columns');
+
+            start();
+        });
+
+        var $activityrow = $datagrid.find('tbody tr');
+        equal($activityrow.length, 1, 'activity row was rendered');
+    });
 
 	asyncTest("should handle header clicks", function () {
 		var stubDataSource = new StubDataSource();


### PR DESCRIPTION
Fix for Issue 170.  A noDataFoundHTML option was added to the DataGrid so custom text/html can be shown if no data is found for a data request.  The default value is '0 items'.
