### PR TITLE
add nested property support to datagrid

### DIFF
--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -161,7 +161,18 @@ define(function(require) {
 				$.each(data.data, function (index, row) {
 					rowHTML += '<tr>';
 					$.each(self.columns, function (index, column) {
-						rowHTML += '<td>' + row[column.property] + '</td>';
+						var pros = column.property.split('.');
+						if(pros.length > 1) {
+						    var tick = 1;
+						    var result = row[pros[0]];
+						    while(result && tick < pros.length) {
+						        result = result[pros[tick]]
+						        tick++;
+						    }
+						    rowHTML += '<td>' + result + '</td>';
+						}
+						else
+						    rowHTML += '<td>' + row[column.property] + '</td>';
 					});
 					rowHTML += '</tr>';
 				});


### PR DESCRIPTION
say I have a "me" object:
{
    name: "JoeHetfield",
    age: 39,
    pet: {
        name: "Back Jack",
        age: 5
    }
}

then I can use datagrid like this:

```
    // INITIALIZING THE DATAGRID
    var dataSource = new StaticDataSource({
        columns: [
            {
                property: 'name',
                label: 'My Name',
                sortable: true
            },
            {
                property: 'age',
                label: 'My Age',
                sortable: true
            },
            {
                property: 'pet.name',
                label: 'Pet Name',
                sortable: true
            },
            {
                property: 'pet.age',
                label: 'Pet Age',
                sortable: true
            }
        ],
        data: dataOfPersonAndTheirPet,
        delay: 250
    });

    $('#MyGrid').datagrid({
        dataSource: dataSource,
        stretchHeight: true
    });
```

property could nested in many level, until property path hit null or undefined, then the result will be "null".
could be useful, I think.
