### PR TITLE
double-click problem for next/prev buttons

### DIFF
--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -212,11 +212,15 @@ define(function(require) {
 		},
 
 		previous: function () {
+			this.$nextpagebtn.attr('disabled', 'disabled');
+			this.$prevpagebtn.attr('disabled', 'disabled');
 			this.options.dataOptions.pageIndex--;
 			this.renderData();
 		},
 
 		next: function () {
+			this.$nextpagebtn.attr('disabled', 'disabled');
+			this.$prevpagebtn.attr('disabled', 'disabled');
 			this.options.dataOptions.pageIndex++;
 			this.renderData();
 		},


### PR DESCRIPTION
Immediately disables next/prev buttons so user can't click again until after data is retrieved and grid populated
