### PR TITLE
* Adds a cycle option to the spinner, so that the value will cycle betwe...

### DIFF
--- a/src/spinner.js
+++ b/src/spinner.js
@@ -137,6 +137,9 @@ define(function(require) {
 				} else {
 					this.value(newVal);
 				}
+			} else if (this.options.cycle) {
+				var cycleVal = dir ? this.options.min : this.options.max;
+				this.value(cycleVal);
 			}
 		},
 

--- a/test/spinner-test.js
+++ b/test/spinner-test.js
@@ -85,4 +85,21 @@ require(['jquery', 'fuelux/spinner'], function($) {
 		equal($spinner.spinner('value'), 3, 'spinner kept existing value');
 	});
 
+	test("should cycle when min or max values are reached", function () {
+		var $spinner = $(spinnerHTML).spinner({
+			min: 1,
+			max: 3,
+			cycle: true
+			});
+		$spinner.spinner('step',true); // 2
+		$spinner.spinner('step',true); // 3
+		$spinner.spinner('step',true); // 1
+		$spinner.spinner('step',true); // 2
+		equal($spinner.spinner('value'), 2, 'spinner value cycled at max');
+		$spinner.spinner('step',false); // 1
+		$spinner.spinner('step',false); // 3
+		$spinner.spinner('step',false); // 2
+		equal($spinner.spinner('value'), 2, 'spinner value cycled at min');
+	});
+
 });


### PR DESCRIPTION
...en min and max when limit is reached.

The use-case for this would be something like time of day, where you might want the player to reach 12 (or 24) hours, click the up button and jump to 1 (and vice versa).

Grunt reported no errors and it built /dist/ fine, but I'm only committing /src/ and /test/ as per the instructions here:

https://github.com/ExactTarget/fuelux/wiki/Contributing-to-Fuel-UX

I tested myself in Chrome, Firefox, Safari and IE 10/9/8, and tried out floats, ints and negative/positive numbers.
