### PR TITLE
Update wizard.js

### DIFF
--- a/src/wizard.js
+++ b/src/wizard.js
@@ -19,7 +19,7 @@ define(function (require) {
 		this.$element = $(element);
 		this.options = $.extend({}, $.fn.wizard.defaults, options);
 		this.currentStep = 1;
-		this.numSteps = this.$element.find('li[data-target]').length;
+		this.numSteps = this.$element.find('.steps li').length;
 		this.$prevBtn = this.$element.find('button.btn-prev');
 		this.$nextBtn = this.$element.find('button.btn-next');
 


### PR DESCRIPTION
- Change li selector so that it will now select only li elements with a "target" data attribute. (data-target), as the li only selector method will also select ANY (.find) ocurrence of li elements and include them in the total step count.
