### PR TITLE
Scope jQuery selectors to allow for multiple wizards on the same page

### DIFF
--- a/src/wizard.js
+++ b/src/wizard.js
@@ -76,7 +76,7 @@ define(function (require) {
 
 			// set display of target element
 			var target = $currentStep.data().target;
-			$('.step-pane').removeClass('active');
+			this.$element.find('.step-pane').removeClass('active');
 			$(target).addClass('active');
 
 			this.$element.trigger('changed');
@@ -85,7 +85,7 @@ define(function (require) {
 		stepclicked: function (e) {
 			var li = $(e.currentTarget);
 
-			var index = $('.steps li').index(li);
+			var index = this.$element.find('.steps li').index(li);
 
 			var evt = $.Event('stepclick');
 			this.$element.trigger(evt, {step: index + 1});


### PR DESCRIPTION
Without this change, clicks on data-target'd elements, such as the
wizard steps list, would cause a global search and update of the active
tabs.  By scoping it to this.$element like the other selectors, you can
have multiple wizards on the same page.
