### PR TITLE
Wizard initialization improvements

### DIFF
--- a/src/wizard.js
+++ b/src/wizard.js
@@ -31,6 +31,9 @@ define(function (require) {
 		this.$prevBtn.on('click', $.proxy(this.previous, this));
 		this.$nextBtn.on('click', $.proxy(this.next, this));
 		this.$element.on('click', 'li.complete', $.proxy(this.stepclicked, this));
+
+		// initialize state
+		this.setState();
 	};
 
 	Wizard.prototype = {
@@ -158,11 +161,14 @@ define(function (require) {
 	// WIZARD DATA-API
 
 	$(function () {
-		$('body').on('mousedown.wizard.data-api', '.wizard', function () {
+		$('body').on('mousedown.wizard.data-api keydown.wizard.data-api', '.wizard', function () {
 			var $this = $(this);
 			if ($this.data('wizard')) return;
 			$this.wizard($this.data());
 		});
+
+		// faux-mousedown to initialize wizards present in the DOM on document load
+		$('.wizard').mousedown();
 	});
 
 });


### PR DESCRIPTION
Initialize state when the wizard initializes (e.g. so prev button gets disabled on step 1).  Initialize wizard on keypress for wizards where the mouse never actually clicks in the wizard and is instead navigated with keyboard.  Initialize wizard on document ready for wizards in the DOM when the page finishes loading, for a better UX.
