### PR TITLE
Fix disable support for Opera

### DIFF
--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -36,7 +36,7 @@ define(function (require) {
 
 		setState: function ($chk) {
 			var checked = $chk.is(':checked');
-			var disabled = $chk.is(':disabled');
+			var disabled = !!$chk.prop('disabled');
 
 			// reset classes
 			this.$icon.removeClass('checked').removeClass('disabled');


### PR DESCRIPTION
Changed the logic for determining if a checkbox should be disabled to start with to use the 'is' jQuery method to the 'prop' jQuery method as not all versions of Opera support the :disabled pseudo selector.
