### PR TITLE
Wizard with multiple navigation options

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,6 @@
 		}
 
 		.step-content {
-			border: 1px solid #D4D4D4;
-			border-top: 0;
-			border-radius: 0 0 4px 4px;
 			padding: 10px;
 			margin-bottom: 10px;
 		}
@@ -583,35 +580,93 @@
 	<!-- WIZARD -->
 	<div>
 		<div id="MyWizard" class="wizard">
-			<ul class="steps">
-				<li data-target="#step1" class="active"><span class="badge badge-info">1</span>Step 1<span class="chevron"></span></li>
-				<li data-target="#step2"><span class="badge">2</span>Step 2<span class="chevron"></span></li>
-				<li data-target="#step3"><span class="badge">3</span>Step 3<span class="chevron"></span></li>
-				<li data-target="#step4"><span class="badge">4</span>Step 4<span class="chevron"></span></li>
-				<li data-target="#step5"><span class="badge">5</span>Step 5<span class="chevron"></span></li>
-				<li data-target="#step6"><span class="badge">6</span>Step 6<span class="chevron"></span></li>
-				<li data-target="#step7"><span class="badge">7</span>Step 7<span class="chevron"></span></li>
-				<li data-target="#step8"><span class="badge">8</span>Step 8<span class="chevron"></span></li>
-				<li data-target="#step9"><span class="badge">9</span>Step 9<span class="chevron"></span></li>
-				<li data-target="#step10"><span class="badge">10</span>Step 10<span class="chevron"></span></li>
-			</ul>
-			<div class="actions">
-				<button class="btn btn-mini btn-prev"> <i class="icon-arrow-left"></i>Prev</button>
-				<button class="btn btn-mini btn-next" data-last="Finish">Next<i class="icon-arrow-right"></i></button>
-			</div>
-		</div>
-		<div class="step-content">
-			<div class="step-pane active" id="step1">This is step 1</div>
-			<div class="step-pane" id="step2">This is step 2</div>
-			<div class="step-pane" id="step3">This is step 3</div>
-			<div class="step-pane" id="step4">This is step 4</div>
-			<div class="step-pane" id="step5">This is step 5</div>
-			<div class="step-pane" id="step6">This is step 6</div>
-			<div class="step-pane" id="step7">This is step 7</div>
-			<div class="step-pane" id="step8">This is step 8</div>
-			<div class="step-pane" id="step9">This is step 9</div>
-			<div class="step-pane" id="step10">This is step 10</div>
-		</div>
+            <div class="wizard-header">
+			    <ul class="steps">
+				    <li data-target="#step1" class="active"><span class="badge badge-info">1</span>Step 1<span class="chevron"></span></li>
+				    <li data-target="#step2"><span class="badge">2</span>Step 2<span class="chevron"></span></li>
+				    <li data-target="#step3"><span class="badge">3</span>Step 3<span class="chevron"></span></li>
+				    <li data-target="#step4"><span class="badge">4</span>Step 4<span class="chevron"></span></li>
+				    <li data-target="#step5"><span class="badge">5</span>Step 5<span class="chevron"></span></li>
+				    <li data-target="#step6"><span class="badge">6</span>Step 6<span class="chevron"></span></li>
+				    <li data-target="#step7"><span class="badge">7</span>Step 7<span class="chevron"></span></li>
+				    <li data-target="#step8"><span class="badge">8</span>Step 8<span class="chevron"></span></li>
+				    <li data-target="#step9"><span class="badge">9</span>Step 9<span class="chevron"></span></li>
+				    <li data-target="#step10"><span class="badge">10</span>Step 10<span class="chevron"></span></li>
+			    </ul>
+			    <div class="actions">
+				    <button class="btn btn-mini btn-prev"> <i class="icon-arrow-left"></i>Prev</button>
+				    <button class="btn btn-mini btn-next" data-last="Finish">Next<i class="icon-arrow-right"></i></button>
+			    </div>
+            </div>
+		
+		    <div class="step-content">
+			    <div class="step-pane active" id="step1">This is step 1</div>
+			    <div class="step-pane" id="step2">This is step 2</div>
+			    <div class="step-pane" id="step3">This is step 3</div>
+			    <div class="step-pane" id="step4">This is step 4</div>
+			    <div class="step-pane" id="step5">This is step 5</div>
+			    <div class="step-pane" id="step6">This is step 6</div>
+			    <div class="step-pane" id="step7">This is step 7</div>
+			    <div class="step-pane" id="step8">This is step 8</div>
+			    <div class="step-pane" id="step9">This is step 9</div>
+			    <div class="step-pane" id="step10">This is step 10</div>
+		    </div>
+        </div>
+
+        <h2>Wizard with multiple .steps and .actions sections</h2>
+
+        <div id="MyWizard2" class="wizard">
+            <div class="wizard-header">
+			    <ul class="steps">
+				    <li data-target="#wizard2-step1" class="active"><span class="badge badge-info">1</span>Step 1<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step2"><span class="badge">2</span>Step 2<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step3"><span class="badge">3</span>Step 3<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step4"><span class="badge">4</span>Step 4<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step5"><span class="badge">5</span>Step 5<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step6"><span class="badge">6</span>Step 6<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step7"><span class="badge">7</span>Step 7<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step8"><span class="badge">8</span>Step 8<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step9"><span class="badge">9</span>Step 9<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step10"><span class="badge">10</span>Step 10<span class="chevron"></span></li>
+			    </ul>
+			    <div class="actions">
+				    <button class="btn btn-mini btn-prev"> <i class="icon-arrow-left"></i>Prev</button>
+				    <button class="btn btn-mini btn-next" data-last="Finish">Next<i class="icon-arrow-right"></i></button>
+			    </div>
+            </div>
+		
+		    <div class="step-content">
+			    <div class="step-pane active" id="wizard2-step1">This is step 1</div>
+			    <div class="step-pane" id="wizard2-step2">This is step 2</div>
+			    <div class="step-pane" id="wizard2-step3">This is step 3</div>
+			    <div class="step-pane" id="wizard2-step4">This is step 4</div>
+			    <div class="step-pane" id="wizard2-step5">This is step 5</div>
+			    <div class="step-pane" id="wizard2-step6">This is step 6</div>
+			    <div class="step-pane" id="wizard2-step7">This is step 7</div>
+			    <div class="step-pane" id="wizard2-step8">This is step 8</div>
+			    <div class="step-pane" id="wizard2-step9">This is step 9</div>
+			    <div class="step-pane" id="wizard2-step10">This is step 10</div>
+		    </div>
+
+            <div class="wizard-footer">
+                <ul class="steps">
+				    <li data-target="#wizard2-step1" class="active"><span class="badge badge-info">1</span>Step 1<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step2"><span class="badge">2</span>Step 2<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step3"><span class="badge">3</span>Step 3<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step4"><span class="badge">4</span>Step 4<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step5"><span class="badge">5</span>Step 5<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step6"><span class="badge">6</span>Step 6<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step7"><span class="badge">7</span>Step 7<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step8"><span class="badge">8</span>Step 8<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step9"><span class="badge">9</span>Step 9<span class="chevron"></span></li>
+				    <li data-target="#wizard2-step10"><span class="badge">10</span>Step 10<span class="chevron"></span></li>
+			    </ul>
+			    <div class="actions">
+				    <button class="btn btn-mini btn-prev"> <i class="icon-arrow-left"></i>Prev</button>
+				    <button class="btn btn-mini btn-next" data-last="Finish">Next<i class="icon-arrow-right"></i></button>
+			    </div>
+            </div>
+        </div>
 
 		<input type="button" class="btn btn-mini" id="btnWizardPrev" value="prev">
 		<input type="button" class="btn btn-mini" id="btnWizardNext" value="next">

--- a/src/less/wizard.less
+++ b/src/less/wizard.less
@@ -9,13 +9,32 @@
 	position: relative;
 	overflow: hidden;
 
-	ul {
+    .wizard-header, .wizard-footer
+    {
+        overflow: hidden;
+        position: relative;
+    }
+
+    .wizard-header
+    {
+        margin-bottom: 10px;
+        border-bottom: 1px solid @navbarBorder;
+    }
+
+    .wizard-footer
+    {
+        margin-top: 10px;
+        border-top: 1px solid @navbarBorder;
+    }
+
+	.steps {
 		list-style: none outside none;
 		padding: 0;
 		margin: 0;
 		width: 4000px;
+        overflow: hidden;
 		
-		li {
+		> li {
 			float: left;
 			margin: 0;
 			padding: 0 20px 0 30px;
@@ -88,6 +107,7 @@
 	.actions {
 		z-index: 1000;
 		position: absolute;
+        top: 0;
 		right: 0;
 		line-height: 46px;
 		float: right;

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -15,17 +15,21 @@ define(function (require) {
 
 	var Wizard = function (element, options) {
 		var kids;
+		var self = this;
 
 		this.$element = $(element);
 		this.options = $.extend({}, $.fn.wizard.defaults, options);
 		this.currentStep = this.options.selectedItem.step;
-		this.numSteps = this.$element.find('.steps li').length;
+		this.numSteps = this.$element.find('.steps:first > li').length;
 		this.$prevBtn = this.$element.find('button.btn-prev');
 		this.$nextBtn = this.$element.find('button.btn-next');
 
-		kids = this.$nextBtn.children().detach();
-		this.nextText = $.trim(this.$nextBtn.text());
-		this.$nextBtn.append(kids);
+		this.$nextBtn.each(function()
+		{
+			kids = $(this).children().detach();
+			self.nextText = $.trim($(this).text());
+			$(this).append(kids);
+		});
 
 		// handle events
 		this.$prevBtn.on('click', $.proxy(this.previous, this));
@@ -33,8 +37,12 @@ define(function (require) {
 		this.$element.on('click', 'li.complete', $.proxy(this.stepclicked, this));
 		
 		if(this.currentStep > 1) {
-            this.selectedItem(this.options.selectedItem);
+			this.selectedItem(this.options.selectedItem);
 		}
+		else {
+			// initialize state
+			this.setState();
+		}	
 	};
 
 	Wizard.prototype = {
@@ -42,78 +50,106 @@ define(function (require) {
 		constructor: Wizard,
 
 		setState: function () {
+			var self = this;
+
 			var canMovePrev = (this.currentStep > 1);
 			var firstStep = (this.currentStep === 1);
 			var lastStep = (this.currentStep === this.numSteps);
 
 			// disable buttons based on current step
-			this.$prevBtn.attr('disabled', (firstStep === true || canMovePrev === false));
+			this.$prevBtn.each(function() { $(this).attr('disabled', (firstStep === true || canMovePrev === false)); });
 
 			// change button text of last step, if specified
-			var data = this.$nextBtn.data();
-			if (data && data.last) {
-				this.lastText = data.last;
-				if (typeof this.lastText !== 'undefined') {
-					// replace text
-					var text = (lastStep !== true) ? this.nextText : this.lastText;
-					var kids = this.$nextBtn.children().detach();
-					this.$nextBtn.text(text).append(kids);
+			this.$nextBtn.each(function()
+			{
+				var data = $(this).data();
+
+				if (data && data.last) {
+					self.lastText = data.last;
+					if (typeof self.lastText !== 'undefined') {
+						// replace text
+						var text = (lastStep !== true) ? self.nextText : self.lastText;
+						var kids = $(this).children().detach();
+						$(this).text(text).append(kids);
+					}
 				}
-			}
+			});
 
 			// reset classes for all steps
-			var $steps = this.$element.find('li');
+			var $steps = this.$element.find('.steps li');
 			$steps.removeClass('active').removeClass('complete');
 			$steps.find('span.badge').removeClass('badge-info').removeClass('badge-success');
 
-			// set class for all previous steps
-			var prevSelector = 'li:lt(' + (this.currentStep - 1) + ')';
-			var $prevSteps = this.$element.find(prevSelector);
-			$prevSteps.addClass('complete');
-			$prevSteps.find('span.badge').addClass('badge-success');
-
-			// set class for current step
-			var currentSelector = 'li:eq(' + (this.currentStep - 1) + ')';
-			var $currentStep = this.$element.find(currentSelector);
-			$currentStep.addClass('active');
-			$currentStep.find('span.badge').addClass('badge-info');
-
-			// set display of target element
-			var target = $currentStep.data().target;
-			$('.step-pane').removeClass('active');
-			$(target).addClass('active');
-
-			// reset the wizard position to the left
-			$('.wizard .steps').attr('style','margin-left: 0');
-
-			// check if the steps are wider than the container div
-			var totalWidth = 0;
-			$('.wizard .steps > li').each(function () {
-				totalWidth += $(this).outerWidth();
-			});
-			var containerWidth = 0;
-			if ($('.wizard .actions').length) {
-				containerWidth = $('.wizard').width() - $('.wizard .actions').outerWidth();
-			} else {
-				containerWidth = $('.wizard').width();
-			}
-			if (totalWidth > containerWidth) {
 			
-				// set the position so that the last step is on the right
-				var newMargin = totalWidth - containerWidth;
-				$('.wizard .steps').attr('style','margin-left: -' + newMargin + 'px');
+			var targetChanged = false;
+
+			this.$element.find('.steps').each(function()
+			{
+				// set class for all previous steps
+				var prevSelector = '> li:lt(' + (self.currentStep - 1) + ')';
+				var $prevSteps = $(this).find(prevSelector);
+				$prevSteps.addClass('complete');
+				$prevSteps.find('span.badge').addClass('badge-success');
+
+				// set class for current step
+				var currentSelector = '> li:eq(' + (self.currentStep - 1) + ')';
+				var $currentStep = $(this).find(currentSelector);
+				$currentStep.addClass('active');
+				$currentStep.find('span.badge').addClass('badge-info');
+
+				// reset the wizard position to the left
+				$(this).attr('style','margin-left: 0');
+
+				// check if the steps are wider than the container div
+				var totalWidth = 0;
+				$(this).find('> li').each(function () {
+					totalWidth += $(this).outerWidth();
+				});
+
+				var $closestActions = $(this).nextAll('.actions').first();
+
+				var containerWidth = 0;
+
+				if ($closestActions.length) {
+					containerWidth = $('.wizard').width() - $closestActions.outerWidth();
+				} else {
+					containerWidth = $('.wizard').width();
+				}
+
+				if (totalWidth > containerWidth) {
+					// set the position so that the last step is on the right
+					var newMargin = totalWidth - containerWidth;
+					$(this).attr('style','margin-left: -' + newMargin + 'px');
 				
-				// set the position so that the active step is in a good
-				// position if it has been moved out of view
-				if ($('.wizard li.active').position().left < 200) {
-					newMargin += $('.wizard li.active').position().left - 200;
-					if (newMargin < 1) {
-						$('.wizard .steps').attr('style','margin-left: 0');
-					} else {
-						$('.wizard .steps').attr('style','margin-left: -' + newMargin + 'px');
+					// set the position so that the active step is in a good
+					// position if it has been moved out of view
+					if ($(this).find('> li.active').position().left < 200) {
+						newMargin += $(this).find('> li.active').position().left - 200;
+						if (newMargin < 1) {
+							$(this).attr('style','margin-left: 0');
+						} else {
+							$(this).attr('style','margin-left: -' + newMargin + 'px');
+						}
 					}
 				}
-			}
+
+				// only process on the first steps target to avoid flicker
+				if(!targetChanged)
+				{
+					targetChanged = true;
+
+					// set display of target element
+					var target = $currentStep.data().target;
+					$(this).find('> li').each(function()
+					{
+						var oldTarget = $(this).data().target;
+						$(oldTarget).removeClass('active');
+					});
+
+					$(target).addClass('active');
+				}
+
+			});
 
 			this.$element.trigger('changed');
 		},
@@ -121,7 +157,7 @@ define(function (require) {
 		stepclicked: function (e) {
 			var li = $(e.currentTarget);
 
-			var index = $('.steps li').index(li);
+			var index = $(e.currentTarget).closest('.steps').find('li').index(li);
 
 			var evt = $.Event('stepclick');
 			this.$element.trigger(evt, {step: index + 1});
@@ -170,7 +206,7 @@ define(function (require) {
 
 				if(step >= 1 && step <= this.numSteps) {
 					this.currentStep = step;
-					this.setState();    
+					this.setState();	
 				}
 
 				retVal = this;	
@@ -202,7 +238,7 @@ define(function (require) {
 	};
 
 	$.fn.wizard.defaults = {
-        selectedItem: {step:1}
+		selectedItem: {step:1}
 	};
 
 	$.fn.wizard.Constructor = Wizard;
@@ -211,11 +247,14 @@ define(function (require) {
 	// WIZARD DATA-API
 
 	$(function () {
-		$('body').on('mousedown.wizard.data-api', '.wizard', function () {
+		$('body').on('mousedown.wizard.data-api keydown.wizard.data-api', '.wizard', function () {
 			var $this = $(this);
 			if ($this.data('wizard')) return;
 			$this.wizard($this.data());
 		});
+
+		// faux-mousedown to initialize wizards present in the DOM on document load
+		$('.wizard').mousedown();
 	});
 
 });


### PR DESCRIPTION
...and wizard-footer for greater specificity of wizard parts.

Wrapped all content of a wizard inside the element with .wizard, whereas the previous version only required the "wizard" features (actions and steps) to be a part of the wrapper.  While this version worked, the steps, being tightly linked to the steps themselves, were not within the same hierarchy, thus making multiple .steps and .actions (as well as other features that go for the entire wizard) nearly impossible.
