### PR TITLE
Fix issue: one wizard controls (prev, next) cause all other wizards' steps to slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,22 +638,21 @@
 			</div>
 		</div>
 		<div class="step-content">
-			<div class="step2-pane active" id="step21">This is step2 1</div>
-			<div class="step2-pane" id="step22">This is step2 2</div>
-			<div class="step2-pane" id="step23">This is step2 3</div>
-			<div class="step2-pane" id="step24">This is step2 4</div>
-			<div class="step2-pane" id="step25">This is step2 5</div>
-			<div class="step2-pane" id="step26">This is step2 6</div>
-			<div class="step2-pane" id="step27">This is step2 7</div>
-			<div class="step2-pane" id="step28">This is step2 8</div>
-			<div class="step2-pane" id="step29">This is step2 9</div>
-			<div class="step2-pane" id="step210">This is step2 10</div>
+			<div class="step-pane active" id="step21">This is step 1</div>
+			<div class="step-pane" id="step22">This is step 2</div>
+			<div class="step-pane" id="step23">This is step 3</div>
+			<div class="step-pane" id="step24">This is step 4</div>
+			<div class="step-pane" id="step25">This is step 5</div>
+			<div class="step-pane" id="step26">This is step 6</div>
+			<div class="step-pane" id="step27">This is step 7</div>
+			<div class="step-pane" id="step28">This is step 8</div>
+			<div class="step-pane" id="step29">This is step 9</div>
+			<div class="step-pane" id="step210">This is step 10</div>
 		</div>
 
 		<input type="button" class="btn btn-mini" id="btnWizardPrev" value="prev">
 		<input type="button" class="btn btn-mini" id="btnWizardNext" value="next">
 		<input type="button" class="btn btn-mini" id="btnWizardStep" value="current step">
-		<input type="button" class="btn btn-mini" id="btnWizardSetStep4" value="step 4">
 	</div>
 
 </div>

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -84,33 +84,33 @@ define(function (require) {
 			$(target).addClass('active');
 
 			// reset the wizard position to the left
-			$('.wizard .steps').attr('style','margin-left: 0');
+            this.$element.find('.steps').first().attr('style','margin-left: 0');
 
 			// check if the steps are wider than the container div
 			var totalWidth = 0;
-			$('.wizard .steps > li').each(function () {
+			this.$element.find('.steps > li').each(function () {
 				totalWidth += $(this).outerWidth();
 			});
 			var containerWidth = 0;
-			if ($('.wizard .actions').length) {
-				containerWidth = $('.wizard').width() - $('.wizard .actions').outerWidth();
+            if (this.$element.find('.actions').length) {
+                containerWidth = this.$element.width() - this.$element.find('.actions').first().outerWidth();
 			} else {
-				containerWidth = $('.wizard').width();
+				containerWidth = this.$element.width();
 			}
 			if (totalWidth > containerWidth) {
 			
 				// set the position so that the last step is on the right
 				var newMargin = totalWidth - containerWidth;
-				$('.wizard .steps').attr('style','margin-left: -' + newMargin + 'px');
+                this.$element.find('.steps').first().attr('style','margin-left: -' + newMargin + 'px');
 				
 				// set the position so that the active step is in a good
 				// position if it has been moved out of view
-				if ($('.wizard li.active').position().left < 200) {
-					newMargin += $('.wizard li.active').position().left - 200;
+                if (this.$element.find('li.active').first().position().left < 200) {
+                    newMargin += this.$element.find('li.active').first().position().left - 200;
 					if (newMargin < 1) {
-						$('.wizard .steps').attr('style','margin-left: 0');
+                        this.$element.find('.steps').first().attr('style','margin-left: 0');
 					} else {
-						$('.wizard .steps').attr('style','margin-left: -' + newMargin + 'px');
+                        this.$element.find('.steps').first().attr('style','margin-left: -' + newMargin + 'px');
 					}
 				}
 			}


### PR DESCRIPTION
Instead of using `$('.wizard')` to select all wizards globally, use `this.$element.find()` and `$.first()` to select the wizard relative to the controls being used.
