### PR TITLE
Fix disappearing borders in datagrid headers in IE

### DIFF
--- a/src/less/datagrid.less
+++ b/src/less/datagrid.less
@@ -50,6 +50,7 @@
 
 		.sortable {
 			cursor: pointer;
+			position: relative;
 
 			&:hover {
 				.gradientBar(@tableBackgroundAccent, @tableBackgroundAccentDark, @textColor, 'none');


### PR DESCRIPTION
This fixes an issue where hovering over the headers in the datagrid in IE will cause the borders to disappear.

Fixes #173
