### PR TITLE
Display column sort indicator set through datagrid construction

### DIFF
--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -85,7 +85,7 @@ define(function (require) {
 		constructor: Datagrid,
 
 		renderColumns: function () {
-			var self = this;
+			var $target;
 
 			this.$footer.attr('colspan', this.columns.length);
 			this.$topheader.attr('colspan', this.columns.length);
@@ -98,7 +98,12 @@ define(function (require) {
 				colHTML += '>' + column.label + '</th>';
 			});
 
-			self.$colheader.append(colHTML);
+			this.$colheader.append(colHTML);
+
+			if (this.options.dataOptions.sortProperty) {
+				$target = this.$colheader.children('th[data-property="' + this.options.dataOptions.sortProperty + '"]');
+				this.updateColumns($target, this.options.dataOptions.sortDirection);
+			}
 		},
 
 		updateColumns: function ($target, direction) {

--- a/test/datagrid-test.js
+++ b/test/datagrid-test.js
@@ -348,6 +348,19 @@ require(['jquery', 'fuelux/datagrid'], function($) {
 		});
 	});
 
+	asyncTest("should be set to start out sorted", function () {
+		var stubDataSource = new this.StubDataSource();
+		var $datagrid = $(this.datagridHTML).datagrid({ dataSource: stubDataSource, dataOptions: { sortProperty: 'property1' } }).one('loaded', function () {
+
+			var $columnHeaders = $datagrid.find('thead tr').eq(1).find('th');
+			ok($columnHeaders.eq(0).hasClass('sorted'), 'header has sorted class');
+			ok($columnHeaders.eq(0).find('i').hasClass('icon-chevron-down'), 'header has sorting indicator');
+			equal($columnHeaders.eq(0).find('i').length, 1, 'there is exactly one sorting indicator');
+
+			start();
+		});
+	});
+
 	function testSetup() {
 
 		this.EmptyDataSource = function () {};


### PR DESCRIPTION
This fixes the issue where setting `dataOptions.sortProperty` at datagrid construction time did not alter the column headers to show the sorting (though it did pass it to the `data` callback, causing the data itself to be sorted).

Fixes #287
