### PR TITLE
Add ability to pass error string back to datagrid

### DIFF
--- a/src/datagrid.js
+++ b/src/datagrid.js
@@ -147,6 +147,18 @@ define(function (require) {
 			this.$tbody.html(this.placeholderRowHTML(this.options.loadingHTML));
 
 			this.options.dataSource.data(this.options.dataOptions, function (data) {
+				if (typeof data === 'string') {
+					// Error-handling
+
+					self.$footerchildren.css('visibility', 'hidden');
+
+					self.$tbody.html(self.errorRowHTML(data));
+					self.stretchHeight();
+
+					self.$element.trigger('loaded');
+					return;
+				}
+
 				var itemdesc = (data.count === 1) ? self.options.itemText : self.options.itemsText;
 				var rowHTML = '';
 
@@ -183,6 +195,11 @@ define(function (require) {
 				self.$element.trigger('loaded');
 			});
 
+		},
+
+		errorRowHTML: function (content) {
+			return '<tr><td style="text-align:center;padding:20px 20px 0 20px;border-bottom:none;" colspan="' +
+				this.columns.length + '"><div class="alert alert-error">' + content + '</div></td></tr>';
 		},
 
 		placeholderRowHTML: function (content) {

--- a/test/datagrid-test.js
+++ b/test/datagrid-test.js
@@ -348,6 +348,45 @@ require(['jquery', 'fuelux/datagrid'], function($) {
 		});
 	});
 
+	asyncTest("should display data source error messages", function () {
+		var errorDataSource = new this.ErrorDataSource();
+		var $datagrid = $(this.datagridHTML).datagrid({ dataSource: errorDataSource }).one('loaded', function () {
+
+			var $columnHeaders = $datagrid.find('thead tr').eq(1).find('th');
+
+			var $datarows = $datagrid.find('tbody tr');
+			equal($datarows.length, 2, 'all rows were rendered');
+
+			$datagrid.one('loaded', function () {
+
+				var $datarows = $datagrid.find('tbody tr');
+				equal($datarows.length, 1, 'only error row rendered');
+
+				var $testcell = $datarows.eq(0).find('td');
+				var $testerroralert = $testcell.children();
+				equal($testcell.attr('colspan'), '2', 'error status spans all columns');
+				equal($testerroralert.length, 1, 'error alert in cell');
+				ok($testerroralert.hasClass('alert alert-error'), 'error alert has correct classes');
+				equal($testerroralert.html(), 'An error occurred on the server: <strong>500 Internal Server Error</strong>', 'error status is displayed');
+
+				var $footerchildren = $datagrid.find('.datagrid-footer-left');
+				equal($footerchildren.css('visibility'), 'hidden', 'footer is correctly hidden');
+
+				$datagrid.one('loaded', function () {
+
+					var $datarows = $datagrid.find('tbody tr');
+					equal($datarows.length, 2, 'all rows were rendered');
+
+					start();
+				});
+
+				$columnHeaders.eq(0).click();
+			});
+
+			$columnHeaders.eq(1).click();
+		});
+	});
+
 	function testSetup() {
 
 		this.EmptyDataSource = function () {};
@@ -368,6 +407,38 @@ require(['jquery', 'fuelux/datagrid'], function($) {
 			setTimeout(function () {
 				callback({ data: [], start: 1, end: 0, count: 0, pages: 0, page: 1 });
 			}, 0);
+		};
+
+		this.ErrorDataSource = function () {};
+
+		this.ErrorDataSource.prototype.columns = function () {
+			return [{
+				property: 'property1',
+				label: 'Property One',
+				sortable: true
+			}, {
+				property: 'property2',
+				label: 'Property Two',
+				sortable: true
+			}];
+		};
+
+		this.ErrorDataSource.prototype.data = function (options, callback) {
+			if (options.sortProperty === 'property2') {
+				setTimeout(function () {
+					callback('An error occurred on the server: <strong>500 Internal Server Error</strong>');
+				}, 0);
+			} else {
+				setTimeout(function () {
+					callback({
+						data: [
+							{ property1: 'A', property2: 'B' },
+							{ property1: 'D', property2: 'E' }
+						],
+						start: 1, end: 2, count: 2, pages: 1, page: 1
+					});
+				}, 0);
+			}
 		};
 
 


### PR DESCRIPTION
This adds the ability for the data source for a `datagrid` to signal that an error occurred fetching the data and provide an error message to display to the user.

Fixes #125

As error is signaled by passing a string as the first argument to the `callback` function instead of an object. The passed string is the HTML to add to the table for the error message.

This is a simple example of a data source doing an AJAX request and passing back a generic error message:

``` javascript
MyDataSource.prototype.data = function data(options, callback) {
  // options ignored for this example
  $.getJSON('/some/data/endpoint')
    .done(function onData(data) { callback({'data': data}); })
    .fail(function onError() { callback('An error occurred fetching the data'); });
};
```
