### PR TITLE
Allowing datepicker to be initialized with null/blank value

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -22,11 +22,17 @@ define(function (require) {
 		this.parseDate     = this.options.parseDate || this.parseDate;
 		this.blackoutDates = this.options.blackoutDates || this.blackoutDates;
 
-		this.date = this.options.date || new Date();
-		this.date = this.parseDate( this.date );
+		if( this.options.date !== null ) {
+			this.date       = this.options.date || new Date();
+			this.date       = this.parseDate( this.date );
+			this.viewDate   = new Date( this.date.valueOf() );
+			this.stagedDate = new Date( this.date.valueOf() );
+		} else {
+			this.date       = null;
+			this.viewDate   = new Date();
+			this.stagedDate = new Date();
+		}
 
-		this.viewDate   = new Date( this.date.valueOf() );
-		this.stagedDate = new Date( this.date.valueOf() );
 		this.viewDate.setHours( 0,0,0,0 );
 		this.stagedDate.setHours( 0,0,0,0 );
 
@@ -702,7 +708,9 @@ define(function (require) {
 		},
 
 		_insertDateIntoInput: function() {
-			this.$element.find('input[type="text"]').val( this.formatDate( this.date ) );
+			if( this.date !== null ) {
+				this.$element.find('input[type="text"]').val( this.formatDate( this.date ) );
+			}
 		},
 
 		_keyupDateUpdate: function( e ) {

--- a/test/datepicker-test.js
+++ b/test/datepicker-test.js
@@ -74,6 +74,15 @@ require(['jquery', 'fuelux/datepicker'], function ($) {
 		equal( pickerDate2, futureDate, 'no markup datepicker initialized with different date than now' );
 	});
 
+	test( 'should initialize with null date', function() {
+		var $sample         = $( html ).find( '#datepicker1' ).datepicker({ date: null });
+		var initializedDate = $sample.datepicker( 'getDate' );
+		var inputValue      = $sample.find( 'input[type="text"]' ).val();
+
+		equal( initializedDate, null, 'datepicker was initialized with null value' );
+		equal( inputValue, '', 'datepicker does not have value in input field' );
+	});
+
 	test( 'should return date using getDate method', function() {
 		var $sample       = $( html ).find( '#datepicker1' ).datepicker();
 		var dateFormatted = new Date( $sample.datepicker( 'getFormattedDate' ) );


### PR DESCRIPTION
Example usage is $('#myDatepicker').datepicker({ date: null });

fixes #332
