### PR TITLE
"Twitter Bootstrap" is now simply Bootstrap

### DIFF
--- a/index-imhtheme.html
+++ b/index-imhtheme.html
@@ -522,7 +522,7 @@ require(['jquery', 'sample/data', 'sample/datasource', 'sample/datasourceTree', 
 	<p class="title"><img src="https://s3.amazonaws.com/fuelux/logo-gray.png" width="600" height="122" alt="Fuel UX">
 		Version 2.6.0</p>
 
-	<p>Fuel UX extends Twitter Bootstrap with additional lightweight JavaScript controls.
+	<p>Fuel UX extends Bootstrap with additional lightweight JavaScript controls.
 		Other benefits include easy installation into web projects, integrated scripts for customizing Bootstrap and
 		Fuel UX, simple updates, and solid optimization for deployment.
 		All functionality is covered by live documentation and unit tests.</p>

--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ require(['jquery', 'sample/data', 'sample/datasource', 'sample/datasourceTree', 
 	<p class="title"><img src="https://s3.amazonaws.com/fuelux/logo-gray.png" width="600" height="122" alt="Fuel UX">
 		Version 2.6.0</p>
 
-	<p>Fuel UX extends Twitter Bootstrap with additional lightweight JavaScript controls.
+	<p>Fuel UX extends Bootstrap with additional lightweight JavaScript controls.
 		Other benefits include easy installation into web projects, integrated scripts for customizing Bootstrap and
 		Fuel UX, simple updates, and solid optimization for deployment.
 		All functionality is covered by live documentation and unit tests.</p>


### PR DESCRIPTION
See http://getbootstrap.com/about/#brand
This pull request is regarding the docs site.
