### PR TITLE
add an 'todayLabel' option to datepicker

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -104,6 +104,7 @@
 		this.options.dropdownWidth = this.options.dropdownWidth || 170;
 		this.options.monthNames    = this.options.monthNames || [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ];
 		this.options.weekdays      = this.options.weekdays || [ "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+		this.options.todayLabel    = this.options.todayLabel || "Today";
 
 		this.options.showYears  = false;
 		this.options.showDays   = true;
@@ -782,7 +783,7 @@
 					}, '</div>' ) +
 
 				'<div class="footer">' +
-					'<div class="center hover">Today</div>' +
+					'<div class="center hover">' + self.options.todayLabel + '</div>' +
 				'</div>' +
 			'</div>';
 		},

--- a/test/datepicker-test.js
+++ b/test/datepicker-test.js
@@ -314,4 +314,34 @@ define(function(require){
 		equal( $el.parent().length, false, 'control has been removed from DOM');
 	});
 
+	test( 'should create dropdown with default label', function() {
+		var $markup = $( html ).find( '#datepicker1' );
+
+		$markup.datepicker({
+			createInput: true
+		});
+
+		var $dropdown = $markup.find( '.dropdown-menu' );
+		var $footer   = $dropdown.find( '.footer' );
+		var $center   = $footer.find( '.center' );
+
+		equal($.trim($center.text()), 'Today', 'hover text equal to "Today"');
+	});
+
+	test( 'should create dropdown with custom today label', function() {
+		var $markup = $( html ).find( '#datepicker1' );
+		var todayString  = "Custom";
+
+		$markup.datepicker({
+			createInput: true,
+			todayLabel: todayString
+		});
+
+		var $dropdown = $markup.find( '.dropdown-menu' );
+		var $footer   = $dropdown.find( '.footer' );
+		var $center   = $footer.find( '.center' );
+
+		equal($.trim($center.text()), 'Custom', 'hover text equal to "Custom"');
+	});
+
 });


### PR DESCRIPTION
- replace the hardcoded 'Today' string in datepicker dropdown
  footer by a configurable option

This allow full i18n using other options and culture.
