### PR TITLE
tree-populate-bug-fix: changes populate parent to be the tree container ...

### DIFF
--- a/js/tree.js
+++ b/js/tree.js
@@ -63,7 +63,7 @@
 
 		populate: function ($el) {
 			var self = this;
-			var $parent = $el.parent();
+			var $parent = ($el.hasClass('tree')) ? $el : $el.parent();
 			var loader = $parent.find('.tree-loader:eq(0)');
 
 			loader.removeClass('hide');


### PR DESCRIPTION
...if $el has the class 'tree'. fixes issue #658
