### PR TITLE
scheduler: fix monthly repeat in setValue()

### DIFF
--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -451,14 +451,14 @@
 					}
 					item = 'weekly';
 				}else if(recur.FREQ==='MONTHLY'){
-					this.$element.find('.repeat-monthly input').removeClass('checked');
+					this.$element.find('.repeat-monthly input, .repeat-monthly label.radio-custom').removeClass('checked');
 					if(recur.BYMONTHDAY){
 						temp = this.$element.find('.repeat-monthly-date');
-						temp.find('input').addClass('checked');
-						temp.find('.select').selectlist('selectByValue', recur.BYMONTHDAY);
+						temp.find('input, label.radio-custom').addClass('checked');
+						temp.find('.selectlist').selectlist('selectByValue', recur.BYMONTHDAY);
 					}else if(recur.BYDAY){
 						temp = this.$element.find('.repeat-monthly-day');
-						temp.find('input').addClass('checked');
+						temp.find('input, label.radio-custom').addClass('checked');
 						if(recur.BYSETPOS){
 							temp.find('.month-day-pos').selectlist('selectByValue', recur.BYSETPOS);
 						}


### PR DESCRIPTION
This fixes two issues I ran into today:
1. I found that it wasn't enough to merely uncheck the input elements but the label elements also had to be unchecked otherwise the visual checkboxes would not update correctly
2. When setting a month-day value, `find('.select')` was not selecting any elements. I believe the correct selector to be `.selectlist` instead since the current markup for the selectlist for `.repeat-monthly-date` does not have its own class like `byday` has `.month-day-pos` and `.month-days`.
