### PR TITLE
Using onAdd adds "undefined" to the pillbox issue #676

### DIFF
--- a/js/pillbox.js
+++ b/js/pillbox.js
@@ -200,7 +200,7 @@
 					if( this.options.edit && this.currentEdit ){
 						self.options.onAdd( items[0], $.proxy(self.saveEdit,this));
 					} else {
-						self.options.onAdd( items[0], $.proxy(self.placeItems,this, true));
+						self.options.onAdd( items[0], $.proxy(self.placeItems, this));
 					}
 				} else {
 					if( this.options.edit && this.currentEdit ){
@@ -418,7 +418,7 @@
 		//Must match syntax of placeItem so addItem callback is called when an item is edited
 		//expecting to receive an array back from the callback containing edited items
 		saveEdit: function() {
-			var item = arguments[0][0];
+			var item = arguments[0][0] ? arguments[0][0] : arguments[0];
 
 			this.currentEdit = $(item.el);
 			this.currentEdit.data('value', item.value);


### PR DESCRIPTION
This fix addresses issue https://github.com/ExactTarget/fuelux/issues/676. It also addresses the same issue but seen while editing not adding a pill when the onAdd method is used.
