### PR TITLE
pillbox-attributes: Add attributes object to addItems method

### DIFF
--- a/index.css
+++ b/index.css
@@ -33,3 +33,8 @@
 #myPlacard1, #myPlacard2, #myPlacard3 {
 	width: 300px;
 }
+
+.example-pill-class {
+	font-style: italic;
+	font-weight: bold;
+}

--- a/index.html
+++ b/index.html
@@ -368,10 +368,10 @@
 				<div class="btn-panel">
 						<!--<button type="button" class="btn btn-default" id="btnPillboxEnable">enable</button>-->
 						<!--<button type="button" class="btn btn-default" id="btnPillboxDisable">disable</button>-->
-						<button type="button" class="btn btn-default" id="btnPillboxAdd">add</button>
-						<button type="button" class="btn btn-default" id="btnPillboxRemoveByValue">remove by value</button>
-						<button type="button" class="btn btn-default" id="btnPillboxRemoveBySelector">remove by selector</button>
-						<button type="button" class="btn btn-default" id="btnPillboxRemoveByText">remove by text</button>
+						<button type="button" class="btn btn-default" id="btnPillboxAdd">add with color</button>
+						<button type="button" class="btn btn-default" id="btnPillboxRemoveByValue">remove by value "item 2"</button>
+						<button type="button" class="btn btn-default" id="btnPillboxRemoveBySelector">remove by selector ".example-pill-class"</button>
+						<button type="button" class="btn btn-default" id="btnPillboxRemoveByText">remove by text "item 3"</button>
 						<button type="button" class="btn btn-default" id="btnPillboxItems">log items to console</button>
 						<button type="button" class="btn btn-default" id="btnPillboxDestroy">destroy and append</button>
 				</div>

--- a/index.js
+++ b/index.js
@@ -232,13 +232,25 @@ define(function(require) {
 	});
 	$('#btnPillboxAdd').click(function () {
 		var newItemCount = $('#myPillbox1 ul li').length + 1;
-		$('#myPillbox1').pillbox('addItems', {text: 'item ' + newItemCount, value: 'item ' + newItemCount} );
+		var backgroundColor = '#'+Math.floor(Math.random()*16777215).toString(16);
+		$('#myPillbox1').pillbox('addItems',
+			{
+				text: 'item ' + newItemCount,
+				value: 'item ' + newItemCount,
+				attr: {
+						'cssClass': 'example-pill-class',
+						'style': 'background-color: ' + backgroundColor + ';',
+						'data-example-attribute': 'true'
+					}
+			});
+	$('#myPillbox1').pillbox('items');
+
 	});
 	$('#btnPillboxRemoveByValue').click(function () {
 		$('#myPillbox1').pillbox('removeByValue', 'item 2');
 	});
 	$('#btnPillboxRemoveBySelector').click(function () {
-		$('#myPillbox1').pillbox('removeBySelector', '.status-success');
+		$('#myPillbox1').pillbox('removeBySelector', '.example-pill-class');
 	});
 	$('#btnPillboxRemoveByText').click(function () {
 		$('#myPillbox1').pillbox('removeByText', 'item 3');

--- a/js/pillbox.js
+++ b/js/pillbox.js
@@ -184,7 +184,12 @@
 						el: self.$pillHTML
 					};
 
+					if(value['attr']) {
+						data['attr'] = value.attr;	// avoid confusion with $.attr();
+					}
+
 					items[i] = data;
+
 				});
 
 				if( this.options.edit && this.currentEdit ){
@@ -271,6 +276,21 @@
 					$item.attr('data-value', item.value);
 					$item.find('span:first').html( item.text );
 
+					// DOM attributes
+					if(item['attr']) {
+						$.each(item['attr'], function(key, value){
+
+							if(key === 'cssClass' || key === 'class') {
+								$item.addClass(value);
+							}
+							else {
+								$item.attr(key, value);
+							}
+
+						});
+
+					}
+
 					newHtml += $item.wrap('<div></div>').parent().html();
 				});
 
@@ -292,7 +312,7 @@
 
 				if( isInternal ){
 					this.$element.trigger('added.fu.pillbox', {
-						text: items[0].text, 
+						text: items[0].text,
 						value: items[0].value
 					});
 				}

--- a/test/pillbox-test.js
+++ b/test/pillbox-test.js
@@ -56,8 +56,23 @@ define(function(require){
 
 		equal($pillbox.pillbox('itemCount'), 0, 'pillbox is initially empty');
 
-		$pillbox.pillbox('addItems', {text:'Item 1', value:1});
-		deepEqual($pillbox.pillbox('items')[0], {text: 'Item 1', value: 1}, 'singe item added has correct text and value');
+		$pillbox.pillbox('addItems',
+			{
+				text: 'Item 1',
+				value: 1,
+				attr: {
+						'cssClass': 'example-pill-class',
+						'style': 'background-color: #0000FF',
+						'data-example-attribute': true
+					}
+			});
+		deepEqual($pillbox.pillbox('items')[0],
+			{
+				text: 'Item 1',
+				value: 1,
+				'exampleAttribute': true
+			},
+		'single item added has correct text, value, and data');
 
 		$pillbox.pillbox('addItems', {text:'Item 2', value:2});
 		$pillbox.pillbox('removeItems');


### PR DESCRIPTION
This Pull request replaces #692 for issue #679.

Allows:

```
$('#myPillbox1').pillbox('addItems',
    {
        text: 'item 1',
        value: 1,
        attr: {
                'cssClass': 'example-pill-class',
                'style': 'background-color: ' + backgroundColor + ';',
                'data-example-attribute': 'true'
            }
    });
```

amd $('#myPillbox1').pillbox('items') returns:

```
{
    text: 'item 1',
    value: 1,
    exampleAttribute: true
};
```

Text and data attributes are the only attributes returned.
