### PR TITLE
tree-rename-dataAttributes: dataAttributes to attr object for consistency w/ pillbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,14 +567,14 @@ define(function(require) {
 			dataSource: function(options, callback){
 				setTimeout(function () {
 					callback({ data: [
-						{ name: 'Ascending and Descending', type: 'folder', dataAttributes: { id: 'folder1' } },
-						{ name: 'Sky and Water I (with custom icon)', type: 'item', dataAttributes: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
-						{ name: 'Drawing Hands', type: 'folder', dataAttributes: { id: 'folder2' } },
-						{ name: 'Waterfall', type: 'item', dataAttributes: { id: 'item2' } },
-						{ name: 'Belvedere', type: 'folder', dataAttributes: { id: 'folder3' } },
-						{ name: 'Relativity (with custom icon)', type: 'item', dataAttributes: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
-						{ name: 'House of Stairs', type: 'folder', dataAttributes: { id: 'folder4' } },
-						{ name: 'Convex and Concave', type: 'item', dataAttributes: { id: 'item4' } }
+						{ name: 'Ascending and Descending', type: 'folder', attr: { id: 'folder1' } },
+						{ name: 'Sky and Water I (with custom icon)', type: 'item', attr: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
+						{ name: 'Drawing Hands', type: 'folder', attr: { id: 'folder2' } },
+						{ name: 'Waterfall', type: 'item', attr: { id: 'item2' } },
+						{ name: 'Belvedere', type: 'folder', attr: { id: 'folder3' } },
+						{ name: 'Relativity (with custom icon)', type: 'item', attr: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
+						{ name: 'House of Stairs', type: 'folder', attr: { id: 'folder4' } },
+						{ name: 'Convex and Concave', type: 'item', attr: { id: 'item4' } }
 					]});
 
 				}, 400);
@@ -603,14 +603,14 @@ define(function(require) {
 		dataSource: function(options, callback){
 			setTimeout(function () {
 				callback({ data: [
-					{ name: 'Ascending and Descending', type: 'folder', dataAttributes: { id: 'folder1' } },
-					{ name: 'Sky and Water I (with custom icon)', type: 'item', dataAttributes: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
-					{ name: 'Drawing Hands', type: 'folder', dataAttributes: { id: 'folder2' } },
-					{ name: 'Waterfall', type: 'item', dataAttributes: { id: 'item2' } },
-					{ name: 'Belvedere', type: 'folder', dataAttributes: { id: 'folder3' } },
-					{ name: 'Relativity (with custom icon)', type: 'item', dataAttributes: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
-					{ name: 'House of Stairs', type: 'folder', dataAttributes: { id: 'folder4' } },
-					{ name: 'Convex and Concave', type: 'item', dataAttributes: { id: 'item4' } }
+					{ name: 'Ascending and Descending', type: 'folder', attr: { id: 'folder1' } },
+					{ name: 'Sky and Water I (with custom icon)', type: 'item', attr: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
+					{ name: 'Drawing Hands', type: 'folder', attr: { id: 'folder2' } },
+					{ name: 'Waterfall', type: 'item', attr: { id: 'item2' } },
+					{ name: 'Belvedere', type: 'folder', attr: { id: 'folder3' } },
+					{ name: 'Relativity (with custom icon)', type: 'item', attr: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
+					{ name: 'House of Stairs', type: 'folder', attr: { id: 'folder4' } },
+					{ name: 'Convex and Concave', type: 'item', attr: { id: 'item4' } }
 				]});
 			}, 400);
 		},

--- a/js/tree.js
+++ b/js/tree.js
@@ -83,16 +83,16 @@
 						$entity.data(value);
 					}
 
-					// Decorate $entity with data making the element
-					// easily accessable with libraries like jQuery.
+					// Decorate $entity with data or other attributes making the
+					// element easily accessable with libraries like jQuery.
 					//
 					// Values are contained within the object returned
-					// for folders and items as dataAttributes:
+					// for folders and items as attr:
 					//
 					// {
 					//     name: "An Item",
 					//     type: 'item',
-					//     dataAttributes = {
+					//     attr = {
 					//         'classes': 'required-item red-text',
 					//         'data-parent': parentId,
 					//         'guid': guid,
@@ -101,8 +101,8 @@
 					// };
 
 					// add attributes to tree-branch or tree-item
-					var dataAttributes = value.dataAttributes || [];
-					$.each(dataAttributes, function(key, value) {
+					var attr = value['attr'] || value.dataAttributes || [];
+					$.each(attr, function(key, value) {
 						switch (key) {
 						case 'class':
 						case 'classes':

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -20,14 +20,14 @@ define(function(require){
 				setTimeout(function () {
 					callback({
 						data: [
-						{ name: 'Ascending and Descending', type: 'folder', dataAttributes: { id: 'folder1' } },
-						{ name: 'Sky and Water I (with custom icon)', type: 'item', dataAttributes: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
-						{ name: 'Drawing Hands', type: 'folder', dataAttributes: { id: 'folder2', 'data-children': false } },
-						{ name: 'Waterfall', type: 'item', dataAttributes: { id: 'item2' } },
-						{ name: 'Belvedere', type: 'folder', dataAttributes: { id: 'folder3' } },
-						{ name: 'Relativity (with custom icon)', type: 'item', dataAttributes: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
-						{ name: 'House of Stairs', type: 'folder', dataAttributes: { id: 'folder4' } },
-						{ name: 'Convex and Concave', type: 'item', dataAttributes: { id: 'item4' } }
+						{ name: 'Ascending and Descending', type: 'folder', attr: { id: 'folder1' } },
+						{ name: 'Sky and Water I (with custom icon)', type: 'item', attr: { id: 'item1', 'data-icon': 'glyphicon glyphicon-file' } },
+						{ name: 'Drawing Hands', type: 'folder', attr: { id: 'folder2', 'data-children': false } },
+						{ name: 'Waterfall', type: 'item', attr: { id: 'item2' } },
+						{ name: 'Belvedere', type: 'folder', attr: { id: 'folder3' } },
+						{ name: 'Relativity (with custom icon)', type: 'item', attr: { id: 'item3', 'data-icon': 'glyphicon glyphicon-picture' } },
+						{ name: 'House of Stairs', type: 'folder', attr: { id: 'folder4' } },
+						{ name: 'Convex and Concave', type: 'item', attr: { id: 'item4' } }
 						]
 					});
 				}, 0);


### PR DESCRIPTION
Adds consistency with pillbox's `addItems` parameter `attr`. Control can still read `dataAttributes`, but it will eventually be deprecated. 
