### PR TITLE
727 Tree Alignment

### DIFF
--- a/less/tree.less
+++ b/less/tree.less
@@ -58,6 +58,7 @@
 			.glyphicon-play {
 				font-size: 10px;
 				padding-right: 5px;
+				padding-left: 7px;
 
 				&:before {
 					position: relative;


### PR DESCRIPTION
Folder selectable had a button around the glyphicon-play icon. Causing added padding. Made default the same amount of padding as folder-selectable.
