### PR TITLE
Add grunt task to promote pull requests when Fuel UX is a submodule or bower component

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,7 @@ module.exports = function (grunt) {
 		}),
 		trickyTestUrl: 'http://localhost:<%= connect.testServer.options.port %>/test/fuelux.html?jquery=' + '1.9.1',
 		travisCITestUrls: ['http://localhost:<%= connect.testServer.options.port %>/test/fuelux.html?jquery=' + '1.9.1'],
+		watchFiles: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
 
 		//Tasks configuration
 		clean: {
@@ -101,13 +102,15 @@ module.exports = function (grunt) {
 			server: {
 				options: {
 					hostname: '*',
-					port: 8000
+					port: 8000,
+					useAvailablePort: true		// don't be greedy
 				}
 			},
 			testServer: {
 				options: {
 					hostname: '*',
-					port: 9000		// allows main server to be run simultaneously 
+					port: 9000,		// allows main server to be run simultaneously
+					useAvailablePort: true		// don't be greedy
 				}
 			}
 		},
@@ -293,14 +296,19 @@ module.exports = function (grunt) {
 		},
 		watch: {
 			full: {
-				files: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
+				files: '<%= watchFiles %>',
 				options: { livereload: true },
 				tasks: ['test', 'dist']
 			},
 			css: {
-				files: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
+				files: '<%= watchFiles %>',
 				options: { livereload: true },
 				tasks: ['distcss']
+			},
+			submodule: {
+				files: '<%= watchFiles %>',
+				options: { livereload: false },
+				tasks: ['test', 'dist']
 			}
 		}
 	});
@@ -352,8 +360,14 @@ module.exports = function (grunt) {
 	/* -------------
 		SERVE
 	------------- */
+	// default serve for contributing to library
 	grunt.registerTask('serve', ['test', 'dist', 'connect:server', 'watch:full']);
+
+	// a faster serve for modifying LESS/CSS only. No tests run.
 	grunt.registerTask('servecss', ['connect:server', 'watch:css']);
 
+	// Use when contributing to Fuel UX from within another project 
+	// (e.g.- git submodule or clone within bower_components)
+	grunt.registerTask('servesubmodule', ['test', 'dist', 'connect:server', 'watch:submodule']);
 
 };


### PR DESCRIPTION
- Also add comments to serve tasks.
- Helps Fuel UX play nice within other projects, especially related Fuel UX projects, and allows running Fuel UX's grunt tests simultaneously.

**Contributing to Fuel UX when using Fuel UX from within another project:**

If `bower_components` folder is your parent project's .gitignore, then `git clone` your forked Fuel UX repository into the bower folder and git will treat it as it's own repository, but not be versioned within your project. Run `npm install` like normal. If your parent project's `.bowerrc` file is set to something besides `bower_components`, you may need manually move the bower files to `bower_components` within the `fuelux` folder.

Use `grunt servesubmodule` for testing Fuel UX simultaneously as you test your own project. This will run JavaScript tests and prevent livereload conflicts allowing you to continuously run test while modifying Fuel UX within your parent project. When you've added your feature to Fuel UX and have it working within your parent project, push to your fork and create a pull request into the upstream Fuel UX to contribute.
