### PR TITLE
Revert "bower-json-version: removing "version" from bower.json since it ...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "fuelux",
   "description": "Extending Bootstrap with additional lightweight JavaScript controls.",
+  "version": "3.1.0",
   "keywords": [
     "application",
     "bootstrap",


### PR DESCRIPTION
...is ignored and we'd have to update it per release"

This reverts commit 170a27f8ba28462f51fbe27406e0be7d03cf4da7.

Version is required for the badger after all
