### PR TITLE
add grunt-bump, updates project version references

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,21 @@ module.exports = function(grunt) {
 		' * Copyright 2012-<%= grunt.template.today("yyyy") %> <%= pkg.author.name %>\n' +
 		' * Licensed under the <%= pkg.license.type %> license (<%= pkg.license.url %>)\n' +
 		' */\n',
+		bump: {
+			options: {
+				files: [ 'bower.json', 'package.json' ],
+				updateConfigs: [ 'pkg' ],
+				commit: true,
+				commitMessage: 'Release %VERSION%',
+				commitFiles: [ 'bower.json', 'README.md', 'package.json' ],
+				createTag: true,
+				tagName: '%VERSION%',
+				tagMessage: '%VERSION%',
+				push: true,
+				pushTo: 'upstream',
+				gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d'
+			}
+		},
 		jqueryCheck: 'if (typeof jQuery === \'undefined\') { throw new Error(\'Fuel UX\\\'s JavaScript requires jQuery\') }\n\n',
 		bootstrapCheck: 'if (typeof jQuery.fn.dropdown === \'undefined\' || typeof jQuery.fn.collapse === \'undefined\') ' +
 		'{ throw new Error(\'Fuel UX\\\'s JavaScript requires Bootstrap\') }\n\n',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bower": "~1.3.9",
     "grunt": "~0.4.5",
     "grunt-banner": "~0.2.2",
+    "grunt-bump": "~0.0.14",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compress": "^0.12.0",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
See https://github.com/vojtajina/grunt-bump#usage-examples for usage

Still need a way to bump versions in cdn references.

Handles #793 'update version'
