### PR TITLE
updated loader docs to previous from prev #840

### DIFF
--- a/_includes/js/loader.html
+++ b/_includes/js/loader.html
@@ -35,7 +35,7 @@
     <dt id="loader-usage-methods-play">.loader('play');</dt>
     <dd>Plays the loader animation, resuming it if paused.</dd>
 
-    <dt id="loader-usage-methods-prev">.loader('prev');</dt>
+    <dt id="loader-usage-methods-prev">.loader('previous');</dt>
     <dd>Decrements the loader animation to the previous frame.</dd>
 
     <dt id="loader-usage-methods-reset">.loader('reset');</dt>


### PR DESCRIPTION
method was listed in docs as 'prev' and should be 'previous'. Fixed the docs to reflect correct method
