### PR TITLE
Update selected background on repeater, datepicker, and tree

### DIFF
--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -52,14 +52,14 @@
 					display: block;
 
 					&:hover {
-						background: #b7e3f8;
+						background: @selectableHover;
 						text-decoration: none;
 					}
 				}
 
 				&.current-day {
 					b, button {
-						border: 1px solid #1d75bb;
+						border: 1px solid #333;
 					}
 				}
 
@@ -97,15 +97,15 @@
 
 				&.selected {
 					span {
-						background: #1d75bb;
+						background: @selected;
 
 						&:hover {
-							background: #0f5f9f;
+							background: @selectedHover;
 						}
 					}
 
 					b, button {
-						color: #fff;
+						color: #8d8787;
 					}
 
 					&.current-day {

--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -1,4 +1,4 @@
-.repeater[data-viewtype="list"] {
+.repeater[data-currentview^="list"] {
 	.repeater-canvas.scrolling {
 		overflow: visible;
 
@@ -53,7 +53,7 @@
 
 			tr {
 				&:focus {
-					outline: 1px dotted #66afe9;
+					outline: 1px dotted #d7d7d7;
 				}
 
 				&.empty {
@@ -68,19 +68,19 @@
 
 				&.selectable{
 					&:hover td {
-						background: #d9edf7;
+						background: @selectableHover;
 						cursor: pointer;
 					}
 				}
 
 				&.selected {
 					&:hover td {
-						background: #428bca;
+						background: @selectedHover;
 					}
 
 					td {
-						background: #66AFE9;
-						color: #fff;
+						background: @selected;
+						color: #333;
 
 						&:first-child {
 							padding-left: 30px;

--- a/less/repeater-thumbnail.less
+++ b/less/repeater-thumbnail.less
@@ -9,17 +9,17 @@
 
 	&.selectable {
 		&:hover {
-			background: #d9edf7;
+			background: @selectableHover;
 			cursor: pointer;
 		}
 	}
 
 	&.selected {
-		background: #66AFE9;
+		background: @selected;
 		color: #fff;
 
 		&:hover {
-			background: #428bca;
+			background: @selectedHover;
 		}
 	}
 

--- a/less/tree.less
+++ b/less/tree.less
@@ -108,7 +108,7 @@
 
 		&.tree-selected .tree-item-name {
 			background-color: @treeSelectBackground;
-			color: #fff;
+			color: #333;
 		}
 
 		label {

--- a/less/variables.less
+++ b/less/variables.less
@@ -148,6 +148,13 @@
 @zindexModalBackdrop:     1040;
 @zindexModal:             1050;
 
+//Selectable Hover, Selected, Selected Hover
+// -------------------------
+@selectableHover: #f1f1f1;
+@selected: #efefef;
+@selectedHover: #d7d7d7;
+
+
 
 // Sprite icons path
 // -------------------------
@@ -304,7 +311,7 @@
 // Tree
 // --------------------------------------------------
 @treeHoverText: @grayLight;
-@treeSelectBackground: #4f4f4f;
+@treeSelectBackground: @selected;
 
 
 // Icons


### PR DESCRIPTION
Changed selected and hover colors to gray, (due to "light blue confusion"--myself included: whether a blue was Marketing Cloud theme or Bootstrap or Fuel UX, etc). Added variables for hover, selected and hover-selected to create consistency. See https://github.com/ExactTarget/fuelux-mctheme/issues/56

[This is @zerosquadron 's PR, but it had merge conflicts.]

_Technically, this is a visual breaking change, since blue things have become 50 shades of gray. :-)_
