### PR TITLE
Repeater header background

### DIFF
--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -93,7 +93,7 @@
 		thead > tr > th {
 			background: #F9F9F9;
 			border-bottom: 1px solid #ddd;
-			border-left: 1px solid #ddd;
+			border-left: 1px solid transparent;
 			border-top: none;
 			color: rgba(0, 0, 0, 0);
 			line-height: 1.42857;


### PR DESCRIPTION
Fixes #875 by making the `th` tag have matching colors as the `.repeater-list-headings` tag
