### PR TITLE
Remove 100 row option from repeater "number of items" + cleanup

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -244,7 +244,6 @@
 								<li data-value="10" data-selected="true"><a href="#">10</a></li>
 								<li data-value="20"><a href="#">20</a></li>
 								<li data-value="50" data-foo="bar" data-fizz="buzz"><a href="#">50</a></li>
-								<li data-value="100"><a href="#">100</a></li>
 							</ul>
 							<input class="hidden hidden-field" name="itemsPerPage" readonly="readonly" aria-hidden="true" type="text"/>
 						</div>

--- a/index.html
+++ b/index.html
@@ -566,8 +566,7 @@
 									<li data-value="5"><a href="#">5</a></li>
 									<li data-value="10" data-selected="true"><a href="#">10</a></li>
 									<li data-value="20"><a href="#">20</a></li>
-									<li data-value="50" data-foo="bar" data-fizz="buzz"><a href="#">50</a></li>
-									<li data-value="100"><a href="#">100</a></li>
+									<li data-value="50"><a href="#">50</a></li>
 								</ul>
 								<input class="hidden hidden-field" name="itemsPerPage" readonly="readonly" aria-hidden="true" type="text"/>
 							</div>

--- a/markup/repeater.html
+++ b/markup/repeater.html
@@ -56,8 +56,7 @@
 						<li data-value="5"><a href="#">5</a></li>
 						<li data-value="10" data-selected="true"><a href="#">10</a></li>
 						<li data-value="20"><a href="#">20</a></li>
-						<li data-value="50" data-foo="bar" data-fizz="buzz"><a href="#">50</a></li>
-						<li data-value="100"><a href="#">100</a></li>
+						<li data-value="50"><a href="#">50</a></li>
 					</ul>
 					<input class="hidden hidden-field" name="itemsPerPage" readonly="readonly" aria-hidden="true" type="text"/>
 				</div>

--- a/test/markup/repeater-markup.html
+++ b/test/markup/repeater-markup.html
@@ -49,8 +49,7 @@
 						<li data-value="5"><a href="#">5</a></li>
 						<li data-value="10" data-selected="true"><a href="#">10</a></li>
 						<li data-value="20"><a href="#">20</a></li>
-						<li data-value="50" data-foo="bar" data-fizz="buzz"><a href="#">50</a></li>
-						<li data-value="100"><a href="#">100</a></li>
+						<li data-value="50"><a href="#">50</a></li>
 					</ul>
 					<input class="hidden hidden-field" name="itemsPerPage" readonly="readonly" aria-hidden="true" type="text"/>
 				</div>


### PR DESCRIPTION
Example markup change. Our repeater may not even support 100 rows depending on the complexity of the column/cell.
