### PR TITLE
Allow multiple grunt projects to 'serve'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,9 @@
 module.exports = function(grunt) {
 	'use strict';
 
+	// use --no-livereload to disable livereload. Helpful to 'serve' multiple projects
+	var isLivereloadEnabled = (typeof grunt.option('livereload') !== 'undefined') ? grunt.option('livereload') : true;
+
 	// Project configuration.
 	grunt.initConfig({
 		// Metadata
@@ -113,13 +116,15 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					hostname: '*',
-					port: 8000
+					port: 8000,
+					useAvailablePort: true	// increment port number, if unavailable...
 				}
 			},
 			testServer: {
 				options: {
 					hostname: '*',
-					port: 9000 // allows main server to be run simultaneously
+					port: 9000, // allows main server to be run simultaneously
+					useAvailablePort: true	// increment port number, if unavailable...
 				}
 			}
 		},
@@ -309,21 +314,21 @@ module.exports = function(grunt) {
 			full: {
 				files: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
 				options: {
-					livereload: true
+					livereload: isLivereloadEnabled
 				},
 				tasks: ['test', 'dist']
 			},
 			css: {
 				files: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
 				options: {
-					livereload: true
+					livereload: isLivereloadEnabled
 				},
 				tasks: ['distcss']
 			},
 			contrib: {
 				files: ['Gruntfile.js', 'fonts/**', 'js/**', 'less/**', 'lib/**', 'test/**', 'index.html', 'dev.html'],
 				options: {
-					livereload: true
+					livereload: isLivereloadEnabled
 				},
 				tasks: ['test']
 			}


### PR DESCRIPTION
- Make connect not port greedy
- Allow disabling livereload with `--no-livereload`

![screenshot 2014-12-04 15 24 59](https://cloud.githubusercontent.com/assets/1290832/5305521/585c84fe-7bca-11e4-9e59-aef858690aa8.png)

Yay! Serve ALL THE THINGS!
