### PR TITLE
tree: nowrap whitespace in tree-branch-header and tree-item

### DIFF
--- a/less/tree.less
+++ b/less/tree.less
@@ -49,6 +49,7 @@
 		.tree-branch-header {
 			position: relative;
 			border-radius: 6px;
+			white-space: nowrap;
 
 			.tree-branch-name:hover {
 				color: @treeHoverText;
@@ -94,6 +95,7 @@
 	}
 
 	.tree-item {
+		white-space: nowrap;
 		position: relative;
 		cursor: pointer;
 		border-radius: 6px;
@@ -128,7 +130,10 @@
 		color: @treeHoverText;
 	}
 
-	// folder selectable
+	// - - - - - - - - - - - - - -
+	// folder selectable option
+	// - - - - - - - - - - - - - -
+
 	&.tree-folder-select {
 
 		.tree-branch {


### PR DESCRIPTION
Fixes #911. Currently there is a nowrap on the tree-item-name part, but since the folder icon is inline-block, the text and folder can line break currently. (Import from FU-pages).
