### PR TITLE
Lots of extra room at bottom of docs #811

### DIFF
--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -53,7 +53,7 @@ dt[id]{
   position: absolute;
   opacity: 0;
   padding: 0 5px 0 10px;
-  height: 100%;
+  height: auto;
   width: 20px;
   color: #000;
   -webkit-transition: opacity 0.3s ease-in-out 0s;
@@ -62,7 +62,7 @@ dt[id]{
 }
 
 .header-anchor .glyphicon {
-	top 0;
+	top: 0;
 }
 
 h1 .header-anchor {

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -40,7 +40,7 @@ define(function(require){
 					return this.top;
 				},
 				bottom: function () {
-					this.bottom = $('.fu-docs-footer').outerHeight(true);
+					this.bottom = $('.fu-footer').outerHeight(true);
 					return this.bottom;
 				}
 			}


### PR DESCRIPTION
Footer reference in application.js was incorrect. The header links that were dynamically generated all had 100% height which ended up being 60,000 px tall. 
Making them auto height removed extra space at bottom of docs.
