### PR TITLE
Checkbox / Radio: Setting checked attribute on underlying input #906

### DIFF
--- a/js/checkbox.js
+++ b/js/checkbox.js
@@ -93,6 +93,7 @@
 		check: function () {
 			this.state.checked = true;
 			this.$element.prop('checked', true);
+			this.$element.attr('checked','checked');
 			this._setCheckedClass();
 			this.$element.trigger( 'checked.fu.checkbox' );
 		},
@@ -100,6 +101,7 @@
 		uncheck: function () {
 			this.state.checked = false;
 			this.$element.prop('checked', false);
+			this.$element.removeAttr('checked');
 			this._resetClasses();
 			this.$element.trigger( 'unchecked.fu.checkbox' );
 		},


### PR DESCRIPTION
Previously checkbox was set to change with prop. This makes selectors like :checked work as expected but was not changing the actual attribute on the input. 
