### PR TITLE
Have to keep qunit where it is version wise. As soon as we upgrade version we have to change the global variables in the tests.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,18 +18,18 @@
   ],
   "homepage": "http://getfuelux.com",
   "dependencies": {
-    "jquery-1.11.0": "jquery#1.11.0",
-    "requirejs": "~2.1.11",
-    "bootstrap": "~3.2.0",
-    "moment": "2.7.0"
+    "jquery": "latest",
+    "requirejs": "2.x",
+    "bootstrap": "3.x",
+    "moment": "2.x"
   },
   "devDependencies": {
     "jquery": null,
     "jquery-1.9.1": "jquery#1.9.1",
     "qunit": "~1.14.0",
-    "requirejs-text": "~2.0.10",
-    "underscore": "~1.6.0",
-    "blanket": "1.1.5"
+    "requirejs-text": "2.x",
+    "underscore": "1.x",
+    "blanket": "1.x"
   },
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "url": "https://raw.github.com/ExactTarget/fuelux/{version}/dist/fuelux.zip",
     "type": "directory",
     "dependencies": {
-      "moment": "http://momentjs.com/downloads/moment-with-langs.js"
+      "moment": "http://momentjs.com/downloads/moment-with-locales.js"
     }
   },
   "dependencies": {

--- a/test/fuelux.html
+++ b/test/fuelux.html
@@ -6,7 +6,7 @@
 
 		<link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css" media="screen">
 
-		<script src="../bower_components/moment/min/moment-with-langs.js"></script>
+		<script src="../bower_components/moment/min/moment-with-locales.js"></script>
 		<script src="../bower_components/qunit/qunit/qunit.js"></script>
 		<script>QUnit.config.autostart = false;</script>
 		<script src="../bower_components/requirejs/require.js"></script>


### PR DESCRIPTION
Have to keep qunit where it is version wise. As soon as we upgrade version we have to change the global variables in the tests.
