### PR TITLE
Add auto-deploy for travis when passing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,32 @@
 language: node_js
 node_js:
-  - 0.10
-before_install: 
-  - time wget http://fuelux-dev.herokuapp.com/dev/node_modules.tar.gz
-  - time tar -zxf node_modules.tar.gz
-  - chmod +x ./node_modules
-install: 
-  - time npm update
-  - time ./node_modules/bower/bin/bower update
-  - time npm update
+- 0.1
+before_install:
+- time wget http://fuelux-dev.herokuapp.com/dev/node_modules.tar.gz
+- time tar -zxf node_modules.tar.gz
+- chmod +x ./node_modules
+install:
+- time npm update
+- time ./node_modules/bower/bin/bower update
+- time npm update
 env:
   global:
-    - secure: "ZK8M500JH/siU5p6jt2XRhBLV9e3N+qjicz59i6Bvkl4X4klUoGV1dMT3kb/\nLi3c7lrU8Liw/dHr+a5kY5XdgCOPjOeMqZ0VRZzH0PqSyRz0Hf2AYDO5mrhX\nMj/zz/CiaE82MIPlJk9Q27LheVpbCOL7q/aBakriCTJIcIxqbig="
-    - secure: "rrbobgc5ZJnt9NnILcJs5CNFQf/fVBGOuFDo8UqSOxNtqmpHeuLTTTqKgvdo\nsHZL3GDo5ujm/pPvrKv41BGi81rPPLMnQyGdmTDRgW5/F5BaKbKoOvK8opuP\n+M1cvJ2Cq14pEK6y2OMAooY2TY4p8MynxsqoKUGOYjmKXsLp1ZE="
+  - secure: |-
+      ZK8M500JH/siU5p6jt2XRhBLV9e3N+qjicz59i6Bvkl4X4klUoGV1dMT3kb/
+      Li3c7lrU8Liw/dHr+a5kY5XdgCOPjOeMqZ0VRZzH0PqSyRz0Hf2AYDO5mrhX
+      Mj/zz/CiaE82MIPlJk9Q27LheVpbCOL7q/aBakriCTJIcIxqbig=
+  - secure: |-
+      rrbobgc5ZJnt9NnILcJs5CNFQf/fVBGOuFDo8UqSOxNtqmpHeuLTTTqKgvdo
+      sHZL3GDo5ujm/pPvrKv41BGi81rPPLMnQyGdmTDRgW5/F5BaKbKoOvK8opuP
+      +M1cvJ2Cq14pEK6y2OMAooY2TY4p8MynxsqoKUGOYjmKXsLp1ZE=
 matrix:
   fast_finish: true
+deploy:
+  provider: heroku
+  api_key:
+    secure: Otn2JCvGSETNBjqQzithRjtz9uyLFkhpyUiXF+oV+j7cnL8W2j7RSQ9Mzd3h0viAC8ONR+S5KbsX513QUVO9ZxFiZEg2Zwv7Qeg9nmuGaosQ23OpHXjllB3rwOrCasJknlXLkYvY7SPR9YrgunK2Gd4OO4ISbyke5RQB4Gq4L80=
+  app:
+    master: fuelux-dev
+    travis-deploy: fuelux-dev
+  on:
+    repo: ExactTarget/fuelux


### PR DESCRIPTION
Allows for continuous integration via https://fuelux-dev.herokuapp.com/dist/js/fuelux.js

Still need to `dist bump` though to update. `grunt dist` task is not set to run on deploy.