### PR TITLE
Fix Sauce Labs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
 install:
 - time npm update
 - time ./node_modules/bower/bin/bower update
-- time npm update
 env:
   global:
   - secure: |-

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -247,7 +247,7 @@ module.exports = function(grunt) {
 					testInterval: 3000,
 					tags: ['<%= sauceUser %>' + '@' + process.env.TRAVIS_BRANCH || '<%= sauceUser %>' + '@local'],
 					browsers: grunt.file.readYAML('sauce_browsers_tricky.yml'),
-					build: process.env.TRAVIS_BUILD_NUMBER || '',
+					build: process.env.TRAVIS_BUILD_NUMBER || '<%= pkg.version %>',
 					testname: process.env.TRAVIS_JOB_ID || Math.floor((new Date()).getTime() / 1000 - 1230768000).toString(),
 					urls: '<%= testUrl %>'
 				}
@@ -258,10 +258,10 @@ module.exports = function(grunt) {
 					key: '<%= sauceKey %>',
 					tunnelTimeout: 45,
 					testInterval: 3000,
-					tags: ['<%= sauceUser %>' + '@' + process.env.TRAVIS_BRANCH || '<%= sauceUser %>@local'],
+					tags: ['<%= pkg.version %>','<%= sauceUser %>' + '@' + process.env.TRAVIS_BRANCH || '<%= sauceUser %>@local'],
 					browsers: grunt.file.readYAML('sauce_browsers.yml'),
-					build: process.env.TRAVIS_BUILD_NUMBER || '',
-					testname: process.env.TRAVIS_JOB_ID || 'grunt-<%= grunt.template.today("dddd, mmmm dS, yyyy, h:MM:ss TT") %>',
+					build: process.env.TRAVIS_BUILD_NUMBER || '<%= pkg.version %>',
+					testname: process.env.TRAVIS_JOB_ID || '<%= pkg.version %>-<%= grunt.template.today("dddd, mmmm dS, yyyy, h:MM:ss TT") %>',
 					urls: '<%= testUrl %>',
 					maxPollRetries: 4,
 					throttled: 3,
@@ -273,6 +273,7 @@ module.exports = function(grunt) {
 					username: '<%= sauceUser %>',
 					key: '<%= sauceKey %>',
 					browsers: grunt.file.readYAML('sauce_browsers.yml'),
+					build: process.env.TRAVIS_BUILD_NUMBER || '<%= pkg.version %>',
 					testname: 'grunt-<%= grunt.template.today("dddd, mmmm dS, yyyy, h:MM:ss TT") %>',
 					urls: '<%= allTestUrls %>'
 				}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,10 @@ module.exports = function(grunt) {
 					browsers: grunt.file.readYAML('sauce_browsers.yml'),
 					build: process.env.TRAVIS_BUILD_NUMBER || '',
 					testname: process.env.TRAVIS_JOB_ID || 'grunt-<%= grunt.template.today("dddd, mmmm dS, yyyy, h:MM:ss TT") %>',
-					urls: '<%= testUrl %>'
+					urls: '<%= testUrl %>',
+					maxPollRetries: 4,
+					throttled: 3,
+					maxRetries: 3
 				}
 			},
 			all: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "type": "BSD-3-Clause"
   },
   "engines": {
-    "node": "0.10.28"
+    "node": ">= 0.8.0"
   },
   "scripts": {
     "main": "devserver.js",
@@ -28,27 +28,35 @@
     "test": "grunt travisci"
   },
   "devDependencies": {
-    "bower": "~1.3.9",
-    "grunt": "~0.4.5",
-    "grunt-banner": "~0.2.2",
+    "bower": "1.x",
+    "connect": "3.x",
+    "grunt": "0.x",
+    "grunt-banner": "0.x",
+    "grunt-cli": "0.x",
+    "grunt-contrib-clean": "0.x",
+    "grunt-contrib-compress": "0.x",
+    "grunt-contrib-connect": "0.x",
+    "grunt-contrib-copy": "0.x",
+    "grunt-contrib-less": "0.x",
+    "grunt-contrib-watch": "0.x",
+    "grunt-curl": "2.x",
+    "grunt-grunticon": "^1.4.0",
+    "grunt-svgmin": "^2.0.0",
+    "grunt-text-replace": "0.x",
+    "grunt-zip": "0.x",
+    "load-grunt-tasks": "0.x",
+    "serve-static": "1.x",
+    "volo": "0.x",
     "grunt-blanket-qunit": "~0.2.0",
-    "grunt-bump": "~0.0.14",
-    "grunt-cli": "~0.1.13",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-compress": "^0.12.0",
-    "grunt-contrib-concat": "^0.5.0",
-    "grunt-contrib-connect": "^0.8.0",
-    "grunt-contrib-copy": "^0.7.0",
+    "grunt-bump": "0.x",
+    "grunt-contrib-concat": "^0.x",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-less": "^0.9.0",
     "grunt-contrib-qunit": "^0.5.2",
     "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1",
     "grunt-html-validation": "~0.1.16",
     "grunt-jsbeautifier": "~0.2.6",
-    "grunt-saucelabs": "~8.3.2",
-    "grunt-text-replace": "^0.4.0",
-    "load-grunt-tasks": "^0.6.0"
+    "grunt-saucelabs": "8.x",
+    "grunt-text-replace": "0.x"
   },
   "keywords": [
     "application",
@@ -75,7 +83,7 @@
     }
   },
   "dependencies": {
-    "connect": "2.14.5",
-    "bower": "~1.3.9"
+    "connect": "3.x",
+    "bower": "1.x"
   }
 }


### PR DESCRIPTION
- Fixes Saucelabs "Bad Gateway" and error and `Could not connect to Sauce Labs API: Error: read ECONNRESET` error.
- Upgrades node dependencies, set to x-range semver format.
- Set build number, to enable Sauce Labs badge in readme.