### PR TITLE
Use .hidden on checkbox and radio toggle elements #987

### DIFF
--- a/js/checkbox.js
+++ b/js/checkbox.js
@@ -129,10 +129,10 @@
 		toggleContainer: function(){
 			if( Boolean( this.$toggleContainer ) ) {
 				if( this.state.checked ) {
-					this.$toggleContainer.removeClass('hide');
+					this.$toggleContainer.removeClass('hide hidden');
 					this.$toggleContainer.attr('aria-hidden', 'false');
 				}else {
-					this.$toggleContainer.addClass('hide');
+					this.$toggleContainer.addClass('hidden');
 					this.$toggleContainer.attr('aria-hidden', 'true');
 				}
 			}

--- a/js/radio.js
+++ b/js/radio.js
@@ -146,13 +146,13 @@
 					group = $('input[name="' + this.groupName + '"]');
 					group.each(function(){
 						var selector = $(this).attr('data-toggle');
-						$(selector).addClass('hide');
+						$(selector).addClass('hidden');
 						$(selector).attr('aria-hidden', 'true');
 					});
-					this.$toggleContainer.removeClass('hide');
+					this.$toggleContainer.removeClass('hide hidden');
 					this.$toggleContainer.attr('aria-hidden', 'false');
 				}else {
-					this.$toggleContainer.addClass('hide');
+					this.$toggleContainer.addClass('hidden');
 					this.$toggleContainer.attr('aria-hidden', 'true');
 				}
 


### PR DESCRIPTION
- Fixes issue #987
- checkbox and radio remove both .hide and .hidden but only add .hidden.