### PR TITLE
Remove david dm badge (devDependencies) from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 #[Fuel UX](http://getfuelux.com/)
 [![Bower version](https://badge.fury.io/bo/fuelux.svg)](http://badge.fury.io/bo/fuelux)
 [![Build Status](https://api.travis-ci.org/ExactTarget/fuelux.svg?branch=master)](http://travis-ci.org/ExactTarget/fuelux)
-[![devDependency Status](https://david-dm.org/exacttarget/fuelux/dev-status.svg)](https://david-dm.org/exacttarget/fuelux#info=devDependencies)
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/fuelux.svg)](https://saucelabs.com/u/fuelux)
 


### PR DESCRIPTION
Insecure status isn't what people might think it means. No one should be using an old version of connect's `serve-static` in production anyway. We aren't.