### PR TITLE
1005   correctly apply focus on step change in wizard

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -294,14 +294,15 @@
 				this.setState();
 			}
 
-			// return focus to control after selecting an option
-			if( this.$prevBtn.is(':disabled') ) {
-				this.$nextBtn.focus();
+			if( this.$prevBtn.is(':focus') ) {
+				// return focus to control after selecting an option
+				if( this.$prevBtn.is(':disabled') ) {
+					this.$nextBtn.focus();
+				}
+				else {
+					this.$prevBtn.focus();
+				}
 			}
-			else {
-				this.$prevBtn.focus();
-			}
-
 		},
 
 		next: function () {
@@ -320,12 +321,14 @@
 				this.$element.trigger('finished.fu.wizard');
 			}
 
-			// return focus to control after selecting an option
-			if( this.$nextBtn.is(':disabled') ) {
-				this.$prevBtn.focus();
-			}
-			else {
-				this.$nextBtn.focus();
+			if( this.$nextBtn.is(':focus') ) {
+				// return focus to control after selecting an option
+				if( this.$nextBtn.is(':disabled') ) {
+					this.$prevBtn.focus();
+				}
+				else {
+					this.$nextBtn.focus();
+				}
 			}
 		},
 


### PR DESCRIPTION
:bug: Avoid clobbering programmatically set focus
:new: If possible, focus on the first applicable form field instead of on next/prev button if focus has not been set programmatically
:lipstick::racehorse: clean up code a little to do less js processing, improve readability, and better conform to JS standards