### PR TITLE
Heroku dist build

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -167,3 +167,10 @@ With Travis installed and the build number acquired now run the following comman
 travis restart 9999
 ```
 
+## Edge servers
+
+A build of master is available at `https://fuelux-dev.herokuapp.com/dist/js/fuelux.js` and `https://fuelux-dev.herokuapp.com/dist/css/fuelux.css`. 
+
+_These files should never be used in production and may not have been fully tested._
+
+To create your own edge server, setup a github web hook on Heroku for this repository and put the app into development mode with `heroku config:set NPM_CONFIG_PRODUCTION=false`.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					hostname: '*',
-					port: 8000,
+					port: process.env.PORT || 8000,
 					useAvailablePort: true	// increment port number, if unavailable...
 				}
 			},

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node devserver.js
+web: grunt dist && node devserver.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "bower": "1.x",
-    "connect": "3.x"
+    "connect": "3.x",
+    "serve-static": "1.x"
   },
   "description": "Base Fuel UX styles and controls",
   "devDependencies": {


### PR DESCRIPTION
Fixes #1003. Switches Heroku process to `grunt dist && node devserver.js` (connect) instead of node and runs dist on deploy/install. This requires all the devDependencies to be installed. To do this, the app needs:

`heroku config:set NPM_CONFIG_PRODUCTION=false`

In conclusion, this allows these to be an automatic "edge server" without any `dist bump` commits.
`https://fuelux-dev.herokuapp.com/dist/js/fuelux.js`
`https://fuelux-dev.herokuapp.com/dist/css/fuelux.css`

Add enhancement for #1003