### PR TITLE
Add destroy support for inline radio

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,7 +503,8 @@
 		<div class="btn-panel">
 			<button type="button" class="btn btn-default" id="btnRadioDisable">disable radio1</button>
 			<button type="button" class="btn btn-default" id="btnRadioEnable">enable radio1</button>
-			<button type="button" class="btn btn-default" id="btnRadioDestroy">destroy and append</button>
+			<button type="button" class="btn btn-default" id="btnRadioDestroy">destroy and append myCustomRadio1</button>
+			<button type="button" class="btn btn-default" id="btnRadioInlineDestroy">destroy and append myCustomInlineRadio1</button>
 		</div>
 
 		<h2>Repeater</h2>

--- a/index.js
+++ b/index.js
@@ -417,10 +417,15 @@ define(function(require) {
 	});
 	$('#btnRadioDestroy').on('click', function() {
 		var $container = $('#myCustomRadio1').parents('.thin-box:first');
-		log($cont);
 		var markup = $('#myCustomRadio1').radio('destroy');
 		$container.append(markup);
 		$('#myRadio1').radio();
+	});
+	$('#btnRadioInlineDestroy').on('click', function() {
+		var $container = $('#myCustomInlineRadio1').parents('.thin-box:first');
+		var markup = $('#myCustomInlineRadio1').radio('destroy');
+		$container.append(markup);
+		$('#myCustomInlineRadio1').radio();
 	});
 
 

--- a/js/radio.js
+++ b/js/radio.js
@@ -35,11 +35,12 @@
 		this.$radio = $(element).is('input[type="radio"]') ? $(element) : $(element).find('input[type="radio"]:first');
 		this.$label = this.$radio.parent();
 		this.groupName = this.$radio.attr('name');
-		this.$parent = this.$label.parent('.radio');
+		this.$blockWrapper = this.$label.parent('.radio');	// only used if block radio control, otherwise radio is inline
+		this.isBlockWrapped = true;	// initialized as a block radio control
 		this.$toggleContainer = null;
 
-		if (this.$parent.length === 0) {
-			this.$parent = null;
+		if (this.$blockWrapper.length === 0) {
+			this.isBlockWrapped = false;
 		}
 
 		var toggleSelector = this.$radio.attr('data-toggle');
@@ -59,13 +60,19 @@
 		constructor: Radio,
 
 		destroy: function () {
-			this.$parent.remove();
 			// remove any external bindings
 			// [none]
 			// empty elements to return to original markup
 			// [none]
 			// return string of markup
-			return this.$parent[0].outerHTML;
+			if (this.isBlockWrapped) {
+				this.$blockWrapper.remove();
+				return this.$blockWrapper[0].outerHTML;
+			}	else {
+				this.$label.remove();
+				return this.$label[0].outerHTML;
+			}
+
 		},
 
 		setState: function ($radio) {
@@ -75,23 +82,23 @@
 			var disabled = !!$radio.prop('disabled');
 
 			this.$label.removeClass('checked');
-			if (this.$parent) {
-				this.$parent.removeClass('checked disabled');
+			if (this.isBlockWrapped) {
+				this.$blockWrapper.removeClass('checked disabled');
 			}
 
 			// set state of radio
 			if (checked === true) {
 				this.$label.addClass('checked');
-				if (this.$parent) {
-					this.$parent.addClass('checked');
+				if (this.isBlockWrapped) {
+					this.$blockWrapper.addClass('checked');
 				}
 
 			}
 
 			if (disabled === true) {
 				this.$label.addClass('disabled');
-				if (this.$parent) {
-					this.$parent.addClass('disabled');
+				if (this.isBlockWrapped) {
+					this.$blockWrapper.addClass('disabled');
 				}
 
 			}
@@ -113,16 +120,16 @@
 		enable: function () {
 			this.$radio.attr('disabled', false);
 			this.$label.removeClass('disabled');
-			if (this.$parent) {
-				this.$parent.removeClass('disabled');
+			if (this.isBlockWrapped) {
+				this.$blockWrapper.removeClass('disabled');
 			}
 		},
 
 		disable: function () {
 			this.$radio.attr('disabled', true);
 			this.$label.addClass('disabled');
-			if (this.$parent) {
-				this.$parent.addClass('disabled');
+			if (this.isBlockWrapped) {
+				this.$blockWrapper.addClass('disabled');
 			}
 		},
 

--- a/test/markup/radio-markup.html
+++ b/test/markup/radio-markup.html
@@ -28,4 +28,20 @@
 		</label>
 	</div>
 
+	<br/>
+	<!--Inline radios-->
+	<label class="radio-custom radio-inline" data-initialize="radio" id="myCustomInlineRadio1">
+		<input checked="checked" class="checked sr-only" name="radio3" type="radio" value=""> <span class="radio-label">1, 2, buckle my shoe</span>
+	</label>
+	<label class="radio-custom radio-inline" data-initialize="radio" id="myCustomInlineRadio2">
+		<input class="sr-only" name="radio3" type="radio" value=""> <span class="radio-label">3, 4, shut the door</span>
+	</label>
+	<label class="radio-custom radio-inline" data-initialize="radio" id="myCustomInlineRadio3">
+		<input class="sr-only" disabled="disabled" name="radio4" type="radio" value=""> <span class="radio-label">5, 6, pick up sticks</span>
+	</label>
+	<label class="radio-custom radio-inline" data-initialize="radio" id="myCustomInlineRadio4">
+		<input checked="checked" class="checked sr-only" disabled="disabled" name="radio4" type="radio" value=""> <span class="radio-label">7, 8, lay them straight</span>
+	</label>
+
+
 </div>

--- a/test/radio-test.js
+++ b/test/radio-test.js
@@ -94,4 +94,13 @@ define(function(require){
 		equal( $(html).find(id).length, false, 'element has been removed from DOM');
 	});
 
+	test("should destroy control [INLINE]", function () {
+		var id = '#myCustomInlineRadio1';
+		var $el = $(html).find(id);
+		var $parentInline = $el.closest('.radio-inline');
+
+		equal($el.radio('destroy'), '' + $parentInline[0].outerHTML, 'returns markup');
+		equal( $(html).find(id).length, false, 'element has been removed from DOM');
+	});
+
 });


### PR DESCRIPTION
Currently `destroy()` searches for `.radio` to remove control, now it will remove label if `.radio` does not exist. Fixes. #1059