### PR TITLE
Repeater Plugin API Refactor

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -393,7 +393,7 @@
 			$table.append($tbody);
 		}
 
-		if (data.items.length < 1) {
+		if (data.items && data.items.length < 1) {
 			$empty = $('<tr class="empty"><td colspan="' + this.list_columns.length + '"></td></tr>');
 			$empty.find('td').append(this.viewOptions.list_noItemsHTML);
 			$tbody.append($empty);

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -123,6 +123,7 @@
 			before: function (helpers) {
 				var alignment = this.viewOptions.thumbnail_alignment;
 				var $cont = this.$canvas.find('.repeater-thumbnail-cont');
+				var data = helpers.data;
 				var response = {};
 				var $empty, validAlignments;
 
@@ -145,7 +146,7 @@
 					}
 				}
 
-				if (helpers.data.items.length < 1) {
+				if (data.items && data.items.length < 1) {
 					$empty = $('<div class="empty"></div>');
 					$empty.append(this.viewOptions.thumbnail_noItemsHTML);
 					$cont.append($empty);

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -578,15 +578,15 @@
 		},
 
 		runRenderer: function (viewTypeObj, data, callback) {
-			var container, i, l, response, repeat, subset;
+			var $container, i, l, response, repeat, subset;
 
-			function addItem (cont, resp) {
+			function addItem ($parent, resp) {
 				var action;
 				if (resp) {
 					action = (resp.action) ? resp.action : 'append';
 					if (action !== 'none' && resp.item !== undefined) {
-						cont = (resp.container !== undefined) ? $(resp.container) : cont;
-						cont[action](resp.item);
+						$parent = (resp.container !== undefined) ? $(resp.container) : $parent;
+						$parent[action](resp.item);
 					}
 				}
 			}
@@ -600,8 +600,8 @@
 					addItem(this.$canvas, response);
 				}
 
-				container = this.$canvas.find('[data-container="true"]:last');
-				container = (container.length > 0) ? container : this.$canvas;
+				$container = this.$canvas.find('[data-container="true"]:last');
+				$container = ($container.length > 0) ? $container : this.$canvas;
 
 				if (viewTypeObj.renderItem) {
 					repeat = viewTypeObj.repeat || 'data.items';
@@ -612,20 +612,31 @@
 					} else {
 						repeat = [];
 						subset = [];
+						if (window.console && window.console.warn) {
+							window.console.warn('WARNING: Repeater plugin "repeat" value must start with either "data" or "this"');
+						}
 					}
 
 					for (i = 0, l = repeat.length; i < l; i++) {
-						subset = subset[repeat[i]];
+						if (subset[repeat[i]] !== undefined){
+							subset = subset[repeat[i]];
+						} else {
+							subset = [];
+							if (window.console && window.console.warn) {
+								window.console.warn('WARNING: Repeater unable to find property to iterate renderItem on.');
+							}
+							break;
+						}
 					}
 
 					for (i = 0, l = subset.length; i < l; i++) {
 						response = viewTypeObj.renderItem.call(this, {
-							container: container,
+							container: $container,
 							data: data,
 							index: i,
 							subset: subset
 						});
-						addItem(container, response);
+						addItem($container, response);
 					}
 				}
 


### PR DESCRIPTION
Fixes #1022 by refactoring plugin API according to new draft specified in the issue.

Note: these changes do not effect the repeater, repeater-list, and repeater-thumbnail developer APIs, only the plugin API. All functionality in regards to repeater, repeater-list, and repeater-thumbnail remains the same. Developing plugins for the repeater is the only thing that is different (and breaking)