### PR TITLE
Repeater Scope Bugfix

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -332,6 +332,7 @@
 		},
 
 		initViewTypes: function (callback) {
+			var self = this;
 			var viewTypes = [];
 			var i, viewTypesLength;
 
@@ -346,7 +347,7 @@
 				}
 
 				if (viewTypes[index].initialize) {
-					viewTypes[index].initialize.call(this, {}, function () {
+					viewTypes[index].initialize.call(self, {}, function () {
 						next();
 					});
 				} else {


### PR DESCRIPTION
Fixing a this / self issue within initViewTypes. This bug was there before the recent repeater plugin API changes, just not caught until now.