### PR TITLE
Grunt QUnit settings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,7 +209,14 @@ module.exports = function(grunt) {
 		qunit: {
 			full: {
 				options: {
-					urls: '<%= allTestUrls %>'
+					urls: '<%= allTestUrls %>',
+					screenshot: true,
+					page: {
+						viewportSize: {
+							width: 1280,
+							height: 1024
+						}
+					}
 				}
 			},
 			simple: ['test/*.html']


### PR DESCRIPTION
Makes QUnit take screenshots of our unit tests and also makes PhantomJS's viewport bigger.