### PR TITLE
Update package.json with latest dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #[Fuel UX](http://getfuelux.com/)
 [![Bower version](https://badge.fury.io/bo/fuelux.svg)](http://badge.fury.io/bo/fuelux)
 [![Build Status](https://api.travis-ci.org/ExactTarget/fuelux.svg?branch=master)](http://travis-ci.org/ExactTarget/fuelux)
+[![devDependency Status](https://david-dm.org/exacttarget/fuelux/dev-status.svg)](https://david-dm.org/exacttarget/fuelux#info=devDependencies)
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/fuelux.svg)](https://saucelabs.com/u/fuelux)
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
   "dependencies": {
     "bower": "1.x",
     "connect": "3.x",
-    "serve-static": "1.x"
+    "serve-static": ">=1.7.2"
   },
   "description": "Base Fuel UX styles and controls",
   "devDependencies": {
-    "bower": "1.x",
-    "connect": "3.x",
     "grunt": "0.x",
     "grunt-banner": "0.x",
     "grunt-blanket-qunit": "~0.2.0",
@@ -37,9 +35,8 @@
     "grunt-saucelabs": "8.x",
     "grunt-text-replace": "0.x",
     "grunt-zip": "0.x",
-    "load-grunt-tasks": "2.x",
-    "semver": "4.x",
-    "serve-static": "1.x"
+    "load-grunt-tasks": "3.x",
+    "semver": "4.x"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
- Remove duplicate entries. `dependencies ` get installed with `devDependencies`
- "Secure" `serve-static` to make the warnings go away. Hopefully no one else is serving Fuel UX as an app.
- Update `load-grunt-tasks`
- Add David badge back to readme