### PR TITLE
Allows for wizard to go RTL

### DIFF
--- a/less/wizard.less
+++ b/less/wizard.less
@@ -33,7 +33,7 @@
 				}
 			}
 		}
-		
+
 		li {
 			float: left;
 			margin: 0;
@@ -85,6 +85,7 @@
 					border-left: 14px solid #f3f4f5;
 				}
 			}
+
 			&.active {
 				background: #f1f6fc;
 				color: @infoText;
@@ -111,6 +112,95 @@
 		li:first-child {
 			border-radius: 4px 0 0 4px;
 			padding-left: 20px;
+		}
+	}
+
+	&.rtl {
+		direction: rtl;
+
+		>.steps {
+			right: 0;
+			left: auto;
+
+			&.previous-disabled {
+				li {
+					&.complete {
+						&:hover {
+							.chevron:before {
+								border-right-color: #f3f4f5;
+							}
+						}
+					}
+				}
+			}
+
+			li {
+				float: right;
+
+				.chevron {
+					right: auto;
+					left: -14px;
+					border-right: 14px solid #d4d4d4;
+					border-left: 0;
+
+
+					&:before {
+						right: auto;
+						left: 1px;
+						border-right: 14px solid #ededed;
+						border-left: 0;
+					}
+				}
+
+				&.active {
+					.chevron {
+						&:before {
+							border-right: 14px solid #f1f6fc;
+						}
+					}
+				}
+
+				&.complete {
+					.chevron {
+						&:before {
+							border-right: 14px solid #f3f4f5;
+						}
+					}
+
+					&:hover {
+						.chevron {
+							&:before {
+								border-right: 14px solid #e7eff8;
+								border-left: none;
+							}
+						}
+					}
+				}
+
+				.badge {
+					margin-left: 8px;
+				}
+			}
+		}
+
+		>.actions {
+			right: auto;
+			left: 0;
+			float: left;
+
+			.btn-prev {
+				span {
+					margin-left: 5px;
+					margin-right: 0;
+				}
+			}
+
+			.btn-next {
+				span {
+					margin-left: 0;
+					margin-right: 5px;
+				}
+			}
 		}
 	}
 
@@ -176,11 +266,12 @@
 
 	// when complete
 	&.complete {
-		> .actions .glyphicon-arrow-right:before {
-			display: none;
-		}
-		> .actions .glyphicon-arrow-right {
-			margin-left: 0;
+		>.actions {
+			.btn-next {
+				.glyphicon {
+					display: none;
+				}
+			}
 		}
 	}
 }

--- a/less/wizard.less
+++ b/less/wizard.less
@@ -121,6 +121,7 @@
 		>.steps {
 			right: 0;
 			left: auto;
+			float: right;
 
 			&.previous-disabled {
 				li {


### PR DESCRIPTION
fixes #1156.

All they have to do is add a class of "rtl" next to wizard. Example of markdown can be found [here](https://gist.github.com/vernak2539/e8e4a9226115a4e042cf)