### PR TITLE
Remove custom build step for wrapping with UMD

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -240,7 +240,9 @@ module.exports = function (grunt) {
 					]
 				},
 				options: {
-					banner: '<%= banner %>',
+					banner: '<%= banner %>\n\n' +
+								'<%= jqueryCheck %>' +
+								'<%= bootstrapCheck %>',
 					process: function (source) {
 						source = '(function ($) {\n\n' + source + '\n})(jQuery);\n\n';
 						return source;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,6 +90,128 @@ module.exports = function (grunt) {
 				}
 			}
 		},
+		umd: {
+			default: {
+				options: {
+					src: [
+						'js/checkbox.js',
+						'js/combobox.js',
+						'js/datepicker.js',
+						'js/dropdown-autoflip.js',
+						'js/loader.js',
+						'js/placard.js',
+						'js/radio.js',
+						'js/search.js',
+						'js/selectlist.js',
+						'js/spinbox.js',
+						'js/tree.js',
+						'js/wizard.js',
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery'],
+						global: ['jQuery']
+					}
+				}
+			},
+			infinite_scroll: {
+				options: {
+					src: [
+						'js/infinite-scroll.js',
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelux/loader'],
+						global: ['jQuery']
+					}
+				}
+			},
+			pillbox: {
+				options: {
+					src: [
+						'js/pillbox.js',
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelux/dropdown-autoflip'],
+						global: ['jQuery']
+					}
+				}
+			},
+			repeater: {
+				options: {
+					src: [
+						'js/repeater.js'
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelux/combobox', 'fuelux/infinite-scroll', 'fuelux/search', 'fuelux/selectlist'],
+						global: ['jQuery']
+					}
+				}
+			},
+			repeater_list: {
+				options: {
+					src: [
+						'js/repeater_list.js'
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelex/repeater'],
+						global: ['jQuery']
+					}
+				}
+			},
+			repeater_thumbnail: {
+				options: {
+					src: [
+						'js/repeater_thumbnail.js'
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelex/repeater'],
+						global: ['jQuery']
+					}
+				}
+			},
+			scheduler: {
+				options: {
+					src: [
+						'js/scheduler.js'
+					],
+					template: 'umd.hbs',
+					dest: 'dist',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'fuelux/combobox', 'fuelux/datepicker', 'fuelux/radio', 'fuelux/selectlist', 'fuelux/spinbox'],
+						global: ['jQuery']
+					}
+				}
+			},
+			fuelux: {
+				options: {
+					src: 'dist/js/fuelux.js',
+					template: 'umd.hbs',
+					deps: {
+						'default': ['$'],
+						'amd': ['jquery', 'bootstrap'],
+						global: ['jQuery']
+					}
+				}
+			}
+		},
 		concat: {
 			dist: {
 				files: {
@@ -118,26 +240,13 @@ module.exports = function (grunt) {
 					]
 				},
 				options: {
-					banner: '<%= banner %>' + '\n\n' +
-					'// For more information on UMD visit: https://github.com/umdjs/umd/' + '\n' +
-					'(function (factory) {' + '\n' +
-					'\tif (typeof define === \'function\' && define.amd) {' + '\n' +
-					'\t\tdefine([\'jquery\', \'bootstrap\'], factory);' + '\n' +
-					'\t} else {' + '\n' +
-					'\t\tfactory(jQuery);' + '\n' +
-					'\t}' + '\n' +
-					'}(function (jQuery) {\n\n' +
-					'<%= jqueryCheck %>' +
-					'<%= bootstrapCheck %>',
-					footer: '\n}));',
+					banner: '<%= banner %>',
 					process: function (source) {
-						source = '(function ($) {\n\n' +
-							source.replace(/\/\/ -- BEGIN UMD WRAPPER PREFACE --(\n|.)*\/\/ -- END UMD WRAPPER PREFACE --/g, '');
-						source = source.replace(/\/\/ -- BEGIN UMD WRAPPER AFTERWORD --(\n|.)*\/\/ -- END UMD WRAPPER AFTERWORD --/g, '') + '\n})(jQuery);\n\n';
+						source = '(function ($) {\n\n' + source + '\n})(jQuery);\n\n';
 						return source;
 					}
 				}
-			}
+			}	
 		},
 		connect: {
 			server: {
@@ -215,7 +324,8 @@ module.exports = function (grunt) {
 				globals: {
 					jQuery: true,
 					define: true,
-					require: true
+					require: true,
+					'$': false
 				},
 				immed: true,
 				latedef: true,
@@ -333,8 +443,8 @@ module.exports = function (grunt) {
 							message: 'Bump version from ' + '<%= pkg.version %>' + ' to:',
 							choices: [
 								// {
-								// 	value: 'build',
-								// 	name:  'Build:  '+ (currentVersion + '-?') + ' Unstable, betas, and release candidates.'
+								//	value: 'build',
+								//	name:  'Build:	'+ (currentVersion + '-?') + ' Unstable, betas, and release candidates.'
 								// },
 								{
 									value: 'patch',
@@ -527,7 +637,7 @@ module.exports = function (grunt) {
 		BUILD
 	------------- */
 	// JS distribution task
-	grunt.registerTask('distjs', 'concat, uglify', ['concat', 'uglify', 'jsbeautifier']);
+	grunt.registerTask('distjs', 'concat, uglify', ['concat', 'umd', 'uglify', 'jsbeautifier']);
 
 	// CSS distribution task
 	grunt.registerTask('distcss', 'Compile LESS into CSS', ['less', 'usebanner', 'delete-temp-less-file']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function (grunt) {
 						'js/selectlist.js',
 						'js/spinbox.js',
 						'js/tree.js',
-						'js/wizard.js',
+						'js/wizard.js'
 					],
 					template: 'umd.hbs',
 					dest: 'dist',
@@ -161,13 +161,13 @@ module.exports = function (grunt) {
 			repeater_list: {
 				options: {
 					src: [
-						'js/repeater_list.js'
+						'js/repeater-list.js'
 					],
 					template: 'umd.hbs',
 					dest: 'dist',
 					deps: {
 						'default': ['$'],
-						'amd': ['jquery', 'fuelex/repeater'],
+						'amd': ['jquery', 'fuelux/repeater'],
 						global: ['jQuery']
 					}
 				}
@@ -175,13 +175,13 @@ module.exports = function (grunt) {
 			repeater_thumbnail: {
 				options: {
 					src: [
-						'js/repeater_thumbnail.js'
+						'js/repeater-thumbnail.js'
 					],
 					template: 'umd.hbs',
 					dest: 'dist',
 					deps: {
 						'default': ['$'],
-						'amd': ['jquery', 'fuelex/repeater'],
+						'amd': ['jquery', 'fuelux/repeater'],
 						global: ['jQuery']
 					}
 				}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Bower version](https://badge.fury.io/bo/fuelux.svg)](http://badge.fury.io/bo/fuelux)
 [![Build Status](https://api.travis-ci.org/ExactTarget/fuelux.svg?branch=master)](http://travis-ci.org/ExactTarget/fuelux)
 [![devDependency Status](https://david-dm.org/exacttarget/fuelux/dev-status.svg)](https://david-dm.org/exacttarget/fuelux#info=devDependencies)
+[![bitHound Score](https://www.bithound.io/ExactTarget/fuelux/badges/score.svg)](https://www.bithound.io/ExactTarget/fuelux)
 
 [![Selenium Test Status](https://saucelabs.com/browser-matrix/fuelux.svg)](https://saucelabs.com/u/fuelux)
 

--- a/js/checkbox.js
+++ b/js/checkbox.js
@@ -11,17 +11,6 @@
 // For more information on UMD visit:
 // https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
 
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.checkbox;
@@ -270,7 +259,3 @@
 			}
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/combobox.js
+++ b/js/combobox.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.combobox;
@@ -249,7 +233,3 @@
 			}
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var INVALID_DATE = 'Invalid Date';
@@ -780,7 +764,3 @@
 			$this.datepicker($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/dropdown-autoflip.js
+++ b/js/dropdown-autoflip.js
@@ -8,36 +8,28 @@
 
 	// -- BEGIN MODULE CODE HERE --
 
-	$(document.body).on('click.fu.dropdown-autoflip', '[data-toggle=dropdown][data-flip]', function (event) {
-		if ($(this).data().flip === "auto") {
-			// have the drop down decide where to place itself
-			_autoFlip($(this).next('.dropdown-menu'));
-		}
-	});
-
-	// For pillbox suggestions dropdown
-	$(document.body).on('suggested.fu.pillbox', function (event, element) {
-		_autoFlip($(element));
-		$(element).parent().addClass('open');
-	});
-
-	function _autoFlip(menu) {
-		// hide while the browser thinks
-		$(menu).css({
-			visibility: "hidden"
-		});
-
-		// decide where to put menu
-		if (dropUpCheck(menu)) {
-			menu.parent().addClass("dropup");
+	function _getContainer(element) {
+		var containerElement, isWindow;
+		if (element.attr('data-target')) {
+			containerElement = element.attr('data-target');
+			isWindow = false;
 		} else {
-			menu.parent().removeClass("dropup");
+			containerElement = window;
+			isWindow = true;
 		}
 
-		// show again
-		$(menu).css({
-			visibility: "visible"
+		$.each(element.parents(), function (index, value) {
+			if ($(value).css('overflow') !== 'visible') {
+				containerElement = value;
+				isWindow = false;
+				return false;
+			}
 		});
+
+		return {
+			overflowElement: $(containerElement),
+			isWindow: isWindow
+		};
 	}
 
 	function dropUpCheck(element) {
@@ -77,29 +69,37 @@
 
 	}
 
-	function _getContainer(element) {
-		var containerElement, isWindow;
-		if (element.attr('data-target')) {
-			containerElement = element.attr('data-target');
-			isWindow = false;
-		} else {
-			containerElement = window;
-			isWindow = true;
-		}
-
-		$.each(element.parents(), function (index, value) {
-			if ($(value).css('overflow') !== 'visible') {
-				containerElement = value;
-				isWindow = false;
-				return false;
-			}
+	function _autoFlip(menu) {
+		// hide while the browser thinks
+		$(menu).css({
+			visibility: "hidden"
 		});
 
-		return {
-			overflowElement: $(containerElement),
-			isWindow: isWindow
-		};
+		// decide where to put menu
+		if (dropUpCheck(menu)) {
+			menu.parent().addClass("dropup");
+		} else {
+			menu.parent().removeClass("dropup");
+		}
+
+		// show again
+		$(menu).css({
+			visibility: "visible"
+		});
 	}
+
+	$(document.body).on('click.fu.dropdown-autoflip', '[data-toggle=dropdown][data-flip]', function (event) {
+		if ($(this).data().flip === "auto") {
+			// have the drop down decide where to place itself
+			_autoFlip($(this).next('.dropdown-menu'));
+		}
+	});
+
+	// For pillbox suggestions dropdown
+	$(document.body).on('suggested.fu.pillbox', function (event, element) {
+		_autoFlip($(element));
+		$(element).parent().addClass('open');
+	});
 
 	// register empty plugin
 	$.fn.dropdownautoflip = function () {

--- a/js/dropdown-autoflip.js
+++ b/js/dropdown-autoflip.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	$(document.body).on('click.fu.dropdown-autoflip', '[data-toggle=dropdown][data-flip]', function (event) {
@@ -121,7 +105,3 @@
 	$.fn.dropdownautoflip = function () {
 		/* empty */
 	};
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/loader'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.infinitescroll;
@@ -179,7 +163,3 @@
 	};
 
 	// NO DATA-API DUE TO NEED OF DATA-SOURCE
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/loader.js
+++ b/js/loader.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.loader;
@@ -161,7 +145,3 @@
 			}
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/pillbox.js
+++ b/js/pillbox.js
@@ -6,26 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/dropdown-autoflip'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	if (!$.fn.dropdownautoflip) {
-		throw new Error('Fuel UX pillbox control requires dropdown-autoflip.');
-	}
-
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.pillbox;
@@ -772,7 +752,3 @@
 			$this.pillbox($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/placard.js
+++ b/js/placard.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.placard;
@@ -291,7 +275,3 @@
 			$this.placard($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/radio.js
+++ b/js/radio.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.radio;
@@ -231,7 +215,3 @@
 			$this.radio($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/repeater'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	if($.fn.repeater){
@@ -491,7 +475,3 @@
 			}
 		}
 	}
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -8,6 +8,267 @@
 
 	// -- BEGIN MODULE CODE HERE --
 
+
+	//ADDITIONAL METHODS
+	function renderColumn ($row, rows, rowIndex, columns, columnIndex) {
+		var className = columns[columnIndex].className;
+		var content = rows[rowIndex][columns[columnIndex].property];
+		var $col = $('<td></td>');
+		var width = columns[columnIndex]._auto_width;
+
+		$col.addClass(((className !== undefined) ? className : '')).append(content);
+		if (width !== undefined) {
+			$col.outerWidth(width);
+		}
+		$row.append($col);
+
+		if (this.viewOptions.list_columnRendered) {
+			this.viewOptions.list_columnRendered({
+				container: $row,
+				columnAttr: columns[columnIndex].property,
+				item: $col,
+				rowData: rows[rowIndex]
+			}, function () {});
+		}
+	}
+
+	function renderHeader ($tr, columns, index) {
+		var chevDown = 'glyphicon-chevron-down';
+		var chevron = '.glyphicon.rlc:first';
+		var chevUp = 'glyphicon-chevron-up';
+		var $div = $('<div class="repeater-list-heading"><span class="glyphicon rlc"></span></div>');
+		var $header = $('<th></th>');
+		var self = this;
+		var $both, className, sortable, $span, $spans;
+
+		$div.data('fu_item_index', index);
+		$div.prepend(columns[index].label);
+		$header.html($div.html()).find('[id]').removeAttr('id');
+		$header.append($div);
+
+		$both = $header.add($div);
+		$span = $div.find(chevron);
+		$spans = $span.add($header.find(chevron));
+
+		className = columns[index].className;
+		if (className !== undefined) {
+			$both.addClass(className);
+		}
+
+		sortable = columns[index].sortable;
+		if (sortable) {
+			$both.addClass('sortable');
+			$div.on('click.fu.repeaterList', function () {
+				self.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
+				if ($div.hasClass('sorted')) {
+					if ($span.hasClass(chevUp)) {
+						$spans.removeClass(chevUp).addClass(chevDown);
+						self.list_sortDirection = 'desc';
+					} else {
+						if (!self.viewOptions.list_sortClearing) {
+							$spans.removeClass(chevDown).addClass(chevUp);
+							self.list_sortDirection = 'asc';
+						} else {
+							$both.removeClass('sorted');
+							$spans.removeClass(chevDown);
+							self.list_sortDirection = null;
+							self.list_sortProperty = null;
+						}
+					}
+
+				} else {
+					$tr.find('th, .repeater-list-heading').removeClass('sorted');
+					$spans.removeClass(chevDown).addClass(chevUp);
+					self.list_sortDirection = 'asc';
+					$both.addClass('sorted');
+				}
+
+				self.render({
+					clearInfinite: true,
+					pageIncrement: null
+				});
+			});
+		}
+
+		if (columns[index].sortDirection === 'asc' || columns[index].sortDirection === 'desc') {
+			$tr.find('th, .repeater-list-heading').removeClass('sorted');
+			$both.addClass('sortable sorted');
+			if (columns[index].sortDirection === 'asc') {
+				$spans.addClass(chevUp);
+				this.list_sortDirection = 'asc';
+			} else {
+				$spans.addClass(chevDown);
+				this.list_sortDirection = 'desc';
+			}
+
+			this.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
+		}
+
+		$tr.append($header);
+	}
+
+	function renderRow ($tbody, rows, index) {
+		var $row = $('<tr></tr>');
+		var self = this;
+		var i, l;
+
+		if (this.viewOptions.list_selectable) {
+			$row.addClass('selectable');
+			$row.attr('tabindex', 0);	// allow items to be tabbed to / focused on
+			$row.data('item_data', rows[index]);
+			$row.on('click.fu.repeaterList', function () {
+				var $item = $(this);
+				if ($item.hasClass('selected')) {
+					$item.removeClass('selected');
+					$item.find('.repeater-list-check').remove();
+					$item.$element.trigger('deselected.fu.repeaterList', $item);
+				} else {
+					if (self.viewOptions.list_selectable !== 'multi') {
+						self.$canvas.find('.repeater-list-check').remove();
+						self.$canvas.find('.repeater-list tbody tr.selected').each(function () {
+							$(this).removeClass('selected');
+							self.$element.trigger('deselected.fu.repeaterList', $(this));
+						});
+					}
+
+					$item.addClass('selected');
+					$item.find('td:first').prepend('<div class="repeater-list-check"><span class="glyphicon glyphicon-ok"></span></div>');
+					self.$element.trigger('selected.fu.repeaterList', $item);
+				}
+			});
+			// allow selection via enter key
+			$row.keyup(function (e) {
+				if (e.keyCode === 13) {
+					// triggering a standard click event to be caught by the row click handler above
+					$row.trigger('click.fu.repeaterList');
+				}
+			});
+		}
+
+		$tbody.append($row);
+
+		for (i = 0, l = this.list_columns.length; i < l; i++) {
+			renderColumn.call(this, $row, rows, index, this.list_columns, i);
+		}
+
+		if (this.viewOptions.list_rowRendered) {
+			this.viewOptions.list_rowRendered({
+				container: $tbody,
+				item: $row,
+				rowData: rows[index]
+			}, function () {});
+		}
+	}
+
+	function renderTbody ($table, data) {
+		var $tbody = $table.find('tbody');
+		var $empty;
+
+		if ($tbody.length < 1) {
+			$tbody = $('<tbody data-container="true"></tbody>');
+			$table.append($tbody);
+		}
+
+		if (data.items && data.items.length < 1) {
+			$empty = $('<tr class="empty"><td colspan="' + this.list_columns.length + '"></td></tr>');
+			$empty.find('td').append(this.viewOptions.list_noItemsHTML);
+			$tbody.append($empty);
+		}
+	}
+
+	function sizeColumns ($tr) {
+		var auto = [];
+		var self = this;
+		var i, l, newWidth, taken;
+
+		if (this.viewOptions.list_columnSizing) {
+			i = 0;
+			taken = 0;
+			$tr.find('th').each(function () {
+				var $th = $(this);
+				var isLast = ($th.next('th').length === 0);
+				var width;
+				if (self.list_columns[i].width !== undefined) {
+					width = self.list_columns[i].width;
+					$th.outerWidth(width);
+					taken += $th.outerWidth();
+					if (!isLast) {
+						self.list_columns[i]._auto_width = width;
+					} else {
+						$th.outerWidth('');
+					}
+
+				} else {
+					auto.push({
+						col: $th,
+						index: i,
+						last: isLast
+					});
+				}
+
+				i++;
+			});
+
+			l = auto.length;
+			if (l > 0) {
+				newWidth = Math.floor((this.$canvas.width() - taken) / l);
+				for (i = 0; i < l; i++) {
+					if (!auto[i].last) {
+						auto[i].col.outerWidth(newWidth);
+						this.list_columns[auto[i].index]._auto_width = newWidth;
+					}
+
+				}
+			}
+		}
+	}
+
+	function renderThead ($table, data) {
+		var columns = data.columns || [];
+		var i, j, l, $thead, $tr;
+
+		function differentColumns (oldCols, newCols) {
+			if (!newCols) {
+				return false;
+			}
+			if (!oldCols || (newCols.length !== oldCols.length)) {
+				return true;
+			}
+			for (i = 0, l = newCols.length; i < l; i++) {
+				if (!oldCols[i]) {
+					return true;
+				} else {
+					for (j in newCols[i]) {
+						if (oldCols[i][j] !== newCols[i][j]) {
+							return true;
+						}
+
+					}
+				}
+
+			}
+			return false;
+		}
+
+		if (this.list_firstRender || differentColumns(this.list_columns, columns)) {
+			$table.find('thead').remove();
+
+			this.list_columns = columns;
+			this.list_firstRender = false;
+			this.$loader.removeClass('noHeader');
+
+			$thead = $('<thead data-preserve="deep"><tr></tr></thead>');
+			$tr = $thead.find('tr');
+			for (i = 0, l = columns.length; i < l; i++) {
+				renderHeader.call(this, $tr, columns, i);
+			}
+			$table.prepend($thead);
+
+			sizeColumns.call(this, $tr);
+		}
+	}
+
+
 	if($.fn.repeater){
 		//ADDITIONAL METHODS
 		$.fn.repeater.Constructor.prototype.list_clearSelectedItems = function () {
@@ -215,263 +476,4 @@
 				return false;
 			}
 		};
-	}
-
-	//ADDITIONAL METHODS
-	function renderColumn ($row, rows, rowIndex, columns, columnIndex) {
-		var className = columns[columnIndex].className;
-		var content = rows[rowIndex][columns[columnIndex].property];
-		var $col = $('<td></td>');
-		var width = columns[columnIndex]._auto_width;
-
-		$col.addClass(((className !== undefined) ? className : '')).append(content);
-		if (width !== undefined) {
-			$col.outerWidth(width);
-		}
-		$row.append($col);
-
-		if (this.viewOptions.list_columnRendered) {
-			this.viewOptions.list_columnRendered({
-				container: $row,
-				columnAttr: columns[columnIndex].property,
-				item: $col,
-				rowData: rows[rowIndex]
-			}, function () {});
-		}
-	}
-
-	function renderHeader ($tr, columns, index) {
-		var chevDown = 'glyphicon-chevron-down';
-		var chevron = '.glyphicon.rlc:first';
-		var chevUp = 'glyphicon-chevron-up';
-		var $div = $('<div class="repeater-list-heading"><span class="glyphicon rlc"></span></div>');
-		var $header = $('<th></th>');
-		var self = this;
-		var $both, className, sortable, $span, $spans;
-
-		$div.data('fu_item_index', index);
-		$div.prepend(columns[index].label);
-		$header.html($div.html()).find('[id]').removeAttr('id');
-		$header.append($div);
-
-		$both = $header.add($div);
-		$span = $div.find(chevron);
-		$spans = $span.add($header.find(chevron));
-
-		className = columns[index].className;
-		if (className !== undefined) {
-			$both.addClass(className);
-		}
-
-		sortable = columns[index].sortable;
-		if (sortable) {
-			$both.addClass('sortable');
-			$div.on('click.fu.repeaterList', function () {
-				self.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
-				if ($div.hasClass('sorted')) {
-					if ($span.hasClass(chevUp)) {
-						$spans.removeClass(chevUp).addClass(chevDown);
-						self.list_sortDirection = 'desc';
-					} else {
-						if (!self.viewOptions.list_sortClearing) {
-							$spans.removeClass(chevDown).addClass(chevUp);
-							self.list_sortDirection = 'asc';
-						} else {
-							$both.removeClass('sorted');
-							$spans.removeClass(chevDown);
-							self.list_sortDirection = null;
-							self.list_sortProperty = null;
-						}
-					}
-
-				} else {
-					$tr.find('th, .repeater-list-heading').removeClass('sorted');
-					$spans.removeClass(chevDown).addClass(chevUp);
-					self.list_sortDirection = 'asc';
-					$both.addClass('sorted');
-				}
-
-				self.render({
-					clearInfinite: true,
-					pageIncrement: null
-				});
-			});
-		}
-
-		if (columns[index].sortDirection === 'asc' || columns[index].sortDirection === 'desc') {
-			$tr.find('th, .repeater-list-heading').removeClass('sorted');
-			$both.addClass('sortable sorted');
-			if (columns[index].sortDirection === 'asc') {
-				$spans.addClass(chevUp);
-				this.list_sortDirection = 'asc';
-			} else {
-				$spans.addClass(chevDown);
-				this.list_sortDirection = 'desc';
-			}
-
-			this.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
-		}
-
-		$tr.append($header);
-	}
-
-	function renderRow ($tbody, rows, index) {
-		var $row = $('<tr></tr>');
-		var self = this;
-		var i, l;
-
-		if (this.viewOptions.list_selectable) {
-			$row.addClass('selectable');
-			$row.attr('tabindex', 0);	// allow items to be tabbed to / focused on
-			$row.data('item_data', rows[index]);
-			$row.on('click.fu.repeaterList', function () {
-				var $item = $(this);
-				if ($item.hasClass('selected')) {
-					$item.removeClass('selected');
-					$item.find('.repeater-list-check').remove();
-					$item.$element.trigger('deselected.fu.repeaterList', $item);
-				} else {
-					if (self.viewOptions.list_selectable !== 'multi') {
-						self.$canvas.find('.repeater-list-check').remove();
-						self.$canvas.find('.repeater-list tbody tr.selected').each(function () {
-							$(this).removeClass('selected');
-							self.$element.trigger('deselected.fu.repeaterList', $(this));
-						});
-					}
-
-					$item.addClass('selected');
-					$item.find('td:first').prepend('<div class="repeater-list-check"><span class="glyphicon glyphicon-ok"></span></div>');
-					self.$element.trigger('selected.fu.repeaterList', $item);
-				}
-			});
-			// allow selection via enter key
-			$row.keyup(function (e) {
-				if (e.keyCode === 13) {
-					// triggering a standard click event to be caught by the row click handler above
-					$row.trigger('click.fu.repeaterList');
-				}
-			});
-		}
-
-		$tbody.append($row);
-
-		for (i = 0, l = this.list_columns.length; i < l; i++) {
-			renderColumn.call(this, $row, rows, index, this.list_columns, i);
-		}
-
-		if (this.viewOptions.list_rowRendered) {
-			this.viewOptions.list_rowRendered({
-				container: $tbody,
-				item: $row,
-				rowData: rows[index]
-			}, function () {});
-		}
-	}
-
-	function renderTbody ($table, data) {
-		var $tbody = $table.find('tbody');
-		var $empty;
-
-		if ($tbody.length < 1) {
-			$tbody = $('<tbody data-container="true"></tbody>');
-			$table.append($tbody);
-		}
-
-		if (data.items && data.items.length < 1) {
-			$empty = $('<tr class="empty"><td colspan="' + this.list_columns.length + '"></td></tr>');
-			$empty.find('td').append(this.viewOptions.list_noItemsHTML);
-			$tbody.append($empty);
-		}
-	}
-
-	function renderThead ($table, data) {
-		var columns = data.columns || [];
-		var i, j, l, $thead, $tr;
-
-		function differentColumns (oldCols, newCols) {
-			if (!newCols) {
-				return false;
-			}
-			if (!oldCols || (newCols.length !== oldCols.length)) {
-				return true;
-			}
-			for (i = 0, l = newCols.length; i < l; i++) {
-				if (!oldCols[i]) {
-					return true;
-				} else {
-					for (j in newCols[i]) {
-						if (oldCols[i][j] !== newCols[i][j]) {
-							return true;
-						}
-
-					}
-				}
-
-			}
-			return false;
-		}
-
-		if (this.list_firstRender || differentColumns(this.list_columns, columns)) {
-			$table.find('thead').remove();
-
-			this.list_columns = columns;
-			this.list_firstRender = false;
-			this.$loader.removeClass('noHeader');
-
-			$thead = $('<thead data-preserve="deep"><tr></tr></thead>');
-			$tr = $thead.find('tr');
-			for (i = 0, l = columns.length; i < l; i++) {
-				renderHeader.call(this, $tr, columns, i);
-			}
-			$table.prepend($thead);
-
-			sizeColumns.call(this, $tr);
-		}
-	}
-
-	function sizeColumns ($tr) {
-		var auto = [];
-		var self = this;
-		var i, l, newWidth, taken;
-
-		if (this.viewOptions.list_columnSizing) {
-			i = 0;
-			taken = 0;
-			$tr.find('th').each(function () {
-				var $th = $(this);
-				var isLast = ($th.next('th').length === 0);
-				var width;
-				if (self.list_columns[i].width !== undefined) {
-					width = self.list_columns[i].width;
-					$th.outerWidth(width);
-					taken += $th.outerWidth();
-					if (!isLast) {
-						self.list_columns[i]._auto_width = width;
-					} else {
-						$th.outerWidth('');
-					}
-
-				} else {
-					auto.push({
-						col: $th,
-						index: i,
-						last: isLast
-					});
-				}
-
-				i++;
-			});
-
-			l = auto.length;
-			if (l > 0) {
-				newWidth = Math.floor((this.$canvas.width() - taken) / l);
-				for (i = 0; i < l; i++) {
-					if (!auto[i].last) {
-						auto[i].col.outerWidth(newWidth);
-						this.list_columns[auto[i].index]._auto_width = newWidth;
-					}
-
-				}
-			}
-		}
 	}

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -8,6 +8,32 @@
 
 	// -- BEGIN MODULE CODE HERE --
 
+	//ADDITIONAL METHODS
+	function fillTemplate (itemData, template) {
+		var invalid = false;
+
+		function replace () {
+			var end, start, val;
+
+			start = template.indexOf('{{');
+			end = template.indexOf('}}', start + 2);
+
+			if (start > -1 && end > -1) {
+				val = $.trim(template.substring(start + 2, end));
+				val = (itemData[val] !== undefined) ? itemData[val] : '';
+				template = template.substring(0, start) + val + template.substring(end + 2);
+			} else {
+				invalid = true;
+			}
+		}
+
+		while (!invalid && template.search('{{') >= 0) {
+			replace(template);
+		}
+
+		return template;
+	}
+
 	if ($.fn.repeater) {
 		//ADDITIONAL METHODS
 		$.fn.repeater.Constructor.prototype.thumbnail_clearSelectedItems = function () {
@@ -183,30 +209,4 @@
 				return false;
 			}
 		};
-	}
-
-	//ADDITIONAL METHODS
-	function fillTemplate (itemData, template) {
-		var invalid = false;
-
-		function replace () {
-			var end, start, val;
-
-			start = template.indexOf('{{');
-			end = template.indexOf('}}', start + 2);
-
-			if (start > -1 && end > -1) {
-				val = $.trim(template.substring(start + 2, end));
-				val = (itemData[val] !== undefined) ? itemData[val] : '';
-				template = template.substring(0, start) + val + template.substring(end + 2);
-			} else {
-				invalid = true;
-			}
-		}
-
-		while (!invalid && template.search('{{') >= 0) {
-			replace(template);
-		}
-
-		return template;
 	}

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/repeater'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	if ($.fn.repeater) {
@@ -226,7 +210,3 @@
 
 		return template;
 	}
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/combobox', 'fuelux/infinite-scroll', 'fuelux/search', 'fuelux/selectlist'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.repeater;
@@ -723,7 +707,3 @@
 		$.fn.repeater = old;
 		return this;
 	};
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -6,26 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery', 'fuelux/combobox', 'fuelux/datepicker', 'fuelux/radio', 'fuelux/selectlist', 'fuelux/spinbox'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	if (!$.fn.combobox || !$.fn.datepicker || !$.fn.radio || !$.fn.selectlist || !$.fn.spinbox) {
-		throw new Error('Fuel UX scheduler control requires combobox, datepicker, radio, selectlist, and spinbox.');
-	}
-
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.scheduler;
@@ -685,7 +665,3 @@
 			$this.scheduler($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/search.js
+++ b/js/search.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.search;
@@ -199,7 +183,3 @@
 			$this.search($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/selectlist.js
+++ b/js/selectlist.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.selectlist;
@@ -243,7 +227,3 @@
 			}
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.spinbox;
@@ -444,7 +428,3 @@
 			}
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/tree.js
+++ b/js/tree.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.tree;
@@ -539,7 +523,3 @@
 
 
 	// NO DATA-API DUE TO NEED OF DATA-SOURCE
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -6,22 +6,6 @@
  * Licensed under the BSD New license.
  */
 
-// -- BEGIN UMD WRAPPER PREFACE --
-
-// For more information on UMD visit:
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
-
-(function (factory) {
-	if (typeof define === 'function' && define.amd) {
-		// if AMD loader is available, register as an anonymous module.
-		define(['jquery'], factory);
-	} else {
-		// OR use browser globals if AMD is not present
-		factory(jQuery);
-	}
-}(function ($) {
-	// -- END UMD WRAPPER PREFACE --
-
 	// -- BEGIN MODULE CODE HERE --
 
 	var old = $.fn.wizard;
@@ -442,7 +426,3 @@
 			$this.wizard($this.data());
 		});
 	});
-
-	// -- BEGIN UMD WRAPPER AFTERWORD --
-}));
-// -- END UMD WRAPPER AFTERWORD --

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-prompt": "1.x",
     "grunt-saucelabs": "8.x",
     "grunt-text-replace": "0.x",
+    "grunt-umd": "^2.3.2",
     "grunt-zip": "0.x",
     "load-grunt-tasks": "3.x",
     "semver": "4.x"

--- a/test/tests.html
+++ b/test/tests.html
@@ -52,7 +52,7 @@
 					paths: {
 						jquery: jQueryPath,
 						bootstrap: 'bower_components/bootstrap/dist/js/bootstrap',
-						fuelux: 'js',
+						fuelux: 'dist/js',
 						tests: window.noMoment ? 'test/tests-no-moment' : 'test/tests' ,
 						text: 'bower_components/requirejs-text/text'
 					},

--- a/umd.hbs
+++ b/umd.hbs
@@ -1,0 +1,16 @@
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module unless amdModuleId is set
+    define({{#if amdModuleId}}'{{amdModuleId}}', {{/if}}[{{{amdDependencies.wrapped}}}], function ({{{amdDependencies.params}}}) {
+      return ({{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}factory({{{amdDependencies.params}}}));
+    });
+  } else {
+		// OR use browser globals if AMD is not present
+    {{#if globalAlias}}root['{{{globalAlias}}}'] = {{else}}{{#if objectToExport}}root['{{{objectToExport}}}'] = {{/if}}{{/if}}factory({{{globalDependencies.normal}}});
+  }
+}(this, function ({{dependencies}}) {
+{{{code}}}
+{{#if objectToExport}}
+return {{{objectToExport}}};
+{{/if}}
+}));


### PR DESCRIPTION
Since the UMD boilerplate code was duplicated and then stripped out in all of the files in the `js` folder, it makes more sense to wrap each individual file and place the wrapped version in the  `dist` folder.

This cleans up the build / code and places all of the usable files into the `dist` folder (rather then being a mix between the `js` and `dist` folders.