### PR TITLE
Datepicker goofy Chrome character fix

### DIFF
--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -21,9 +21,11 @@
 
 			/* for spacing */
 			tbody:before {
-				line-height:3px;
-				content:"\200C";
-				display:block;
+				color: transparent;
+				content: "\200C";
+				display: block;
+				line-height: 3px;
+				visibility: hidden;
 			}
 
 			td, th {


### PR DESCRIPTION
fixes #1135 - corrects the random appearance of the tbody:before character by making it totally invisible