### PR TITLE
Add grunt UMD to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-prompt": "1.x",
     "grunt-saucelabs": "8.x",
     "grunt-text-replace": "0.x",
+    "grunt-umd": "2.x",
     "grunt-zip": "0.x",
     "load-grunt-tasks": "3.x",
     "semver": "4.x"


### PR DESCRIPTION
This should allow #1169 to pass once it's merged and pushed out to Heroku edge server, so then TravisCI can pull it down.