### PR TITLE
Ignore clicks on disabled menu items

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -34,6 +34,11 @@ define(function(require) {
 
         itemclicked: function (e) {
             this.$selectedItem = $(e.target).parent();
+
+            if (this.$selectedItem.is('.disabled')) {
+                return;
+            }
+
             this.$hiddenField.val(this.$selectedItem.attr('data-value'));
             this.$label.text(this.$selectedItem.text());
 

--- a/test/select-test.js
+++ b/test/select-test.js
@@ -119,4 +119,24 @@ require(['jquery', 'fuelux/select'], function ($) {
 		equal(selectedText, 'One', 'text passed in from changed event');
 		equal(selectedValue, 1, 'value passed in from changed event');
 	});
+
+	test("should not fire changed event on disabled items", function () {
+		var eventFired = false;
+		var selectedText = '';
+		var selectedValue = '';
+
+		var $select = $(html).select().on('changed', function (evt, data) {
+			eventFired = true;
+			selectedText = data.text;
+			selectedValue = data.value;
+		});
+
+		// Disable menu item then simulate changed event
+		$select.find('li:first').addClass('disabled')
+			.find('a').click();
+
+		equal(eventFired, false, 'changed event not fired');
+		equal(selectedText, '', 'text not changed');
+		equal(selectedValue, '', 'value not changed');
+	});
 });


### PR DESCRIPTION
The Select component shouldn't allow a menu option with the 'disabled' class to be selected (see [Disabled menu options](http://getbootstrap.com/2.3.2/components.html)).

It is easy enough to bind a click handler to Select component's DOM element to prevent this behaviour, but there is no way to achieve this for dynamically inserted Select components.  Many MVC frameworks use event delegation to handle events for dynamically inserted DOM content, so there is no way to prevent this behaviour in such frameworks (at least not without breaking the framework's conventions by hacking in a workaround).

[This jsfiddle](http://jsfiddle.net/warby_/an0ws9nq/1/) might help to explain the issue a bit more clearly.