### PR TITLE
Repeater better defaults

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -345,7 +345,7 @@
 				if ($item.hasClass('selected')) {
 					$item.removeClass('selected');
 					$item.find('.repeater-list-check').remove();
-					$item.$element.trigger('deselected.fu.repeaterList', $item);
+					self.$element.trigger('deselected.fu.repeaterList', $item);
 				} else {
 					if (self.viewOptions.list_selectable !== 'multi') {
 						self.$canvas.find('.repeater-list-check').remove();

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -146,7 +146,7 @@
 			list_columnSyncing: true,
 			list_highlightSortedColumn: false,
 			list_infiniteScroll: false,
-			list_noItemsHTML: '',
+			list_noItemsHTML: 'no items found',
 			list_selectable: false,
 			list_sortClearing: false,
 			list_rowRendered: null

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -106,6 +106,7 @@
 			thumbnail_alignment: 'left',
 			thumbnail_infiniteScroll: false,
 			thumbnail_itemRendered: null,
+			thumbnail_noItemsHTML: 'no items found',
 			thumbnail_selectable: false,
 			thumbnail_template: '<div class="thumbnail repeater-thumbnail"><img height="75" src="{{src}}" width="65"><span>{{name}}</span></div>'
 		});
@@ -139,11 +140,12 @@
 						alignment = (validAlignments[alignment]) ? alignment : 'justify';
 						$cont.addClass('align-' + alignment);
 						this.thumbnail_injectSpacers = true;
-						response.item = $cont;
 					} else {
 						this.thumbnail_injectSpacers = false;
-						response.action = 'none';
 					}
+					response.item = $cont;
+				} else {
+					response.action = 'none';
 				}
 
 				if (data.items && data.items.length < 1) {

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -367,9 +367,9 @@
 		},
 
 		itemization: function (data) {
-			this.$count.html(data.count || '');
-			this.$end.html(data.end || '');
-			this.$start.html(data.start || '');
+			this.$count.html((data.count!==undefined) ? data.count : '?');
+			this.$end.html((data.end!==undefined) ? data.end : '?');
+			this.$start.html((data.start!==undefined) ? data.start : '?');
 		},
 
 		next: function (e) {
@@ -516,6 +516,8 @@
 			dataOptions = this.getDataOptions(options);
 
 			this.viewOptions.dataSource(dataOptions, function (data) {
+				data = data || {};
+
 				if (self.infiniteScrollingEnabled) {
 					self.infiniteScrollingCallback({});
 				} else {
@@ -708,7 +710,9 @@
 	};
 
 	$.fn.repeater.defaults = {
-		dataSource: function (options, callback) {},
+		dataSource: function (options, callback) {
+			callback({ count: 0, end: 0, items: [], page: 0, pages: 1, start: 0 });
+		},
 		defaultView: -1,	//should be a string value. -1 means it will grab the active view from the view controls
 		dropPagingCap: 10,
 		staticHeight: -1,	//normally true or false. -1 means it will look for data-staticheight on the element

--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -59,6 +59,7 @@
 				&.empty {
 					td {
 						border-bottom: none;
+						font-size: 14px;
 						font-style: italic;
 						padding: 20px;
 						text-align: center;

--- a/less/repeater-thumbnail.less
+++ b/less/repeater-thumbnail.less
@@ -53,6 +53,7 @@
 		&.align-right { text-align: right; }
 
 		div.empty {
+			font-size: 14px;
 			font-style: italic;
 			padding: 14px 10px 20px;
 			text-align: center;

--- a/less/repeater-thumbnail.less
+++ b/less/repeater-thumbnail.less
@@ -54,7 +54,7 @@
 
 		div.empty {
 			font-style: italic;
-			padding: 20px 10px;
+			padding: 14px 10px 20px;
 			text-align: center;
 		}
 


### PR DESCRIPTION
Fixes #1167 by allowing repeater to load if no dataSource has been provided. Also attempts to address issue #1166 by making the repeater still function if bad data or no data is passed back in the dataSource, and provides better defaults for itemization and pagination in the event of poor data scenarios.

Also fixes a random bug I noticed with the `deselected` event in repeater-list