### PR TITLE
Spinner: use data attributes when initialising indirectly

### DIFF
--- a/src/spinner.js
+++ b/src/spinner.js
@@ -201,6 +201,8 @@ define(function(require) {
 			var data    = $this.data( 'spinner' );
 			var options = typeof option === 'object' && option;
 
+			options = $.extend({}, $this.data(), options);
+
 			if( !data ) $this.data('spinner', (data = new Spinner( this, options ) ) );
 			if( typeof option === 'string' ) methodReturn = data[ option ].apply( data, args );
 		});

--- a/test/spinner-test.js
+++ b/test/spinner-test.js
@@ -34,6 +34,17 @@ require(['jquery', 'fuelux/spinner'], function($) {
 		'</button>' +
 		'</div>';
 
+	var spinnerHTMLWithDataAttributes = '<div id="ex-spinner" class="spinner"' +
+			' data-min="5" data-max="20" data-value="7" data-cycle="true">' +
+		'<input type="text" class="input-mini spinner-input">' +
+		'<button class="btn  spinner-up">' +
+		'<i class="icon-chevron-up"></i>' +
+		'</button>' +
+		'<button class="btn spinner-down">' +
+		'<i class="icon-chevron-down"></i>' +
+		'</button>' +
+		'</div>';
+
 	test("should behave as designed", function () {
 		var $spinner = $(spinnerHTML).spinner();
 
@@ -102,4 +113,23 @@ require(['jquery', 'fuelux/spinner'], function($) {
 		equal($spinner.spinner('value'), 2, 'spinner value cycled at min');
 	});
 
+	test("instantiating indirectly via method uses data attributes", function() {
+		var $spinner = $(spinnerHTMLWithDataAttributes);
+		var expected = {
+			max: 20,
+			min: 5,
+			value: 7,
+			cycle: true
+		};
+		var options;
+
+		// Call a method to indirectly instantiate the spinner
+		$spinner.spinner('disable');
+
+		options = $spinner.data('spinner').options;
+
+		for (var e in expected) {
+			equal(options[e], expected[e]);
+		}
+	});
 });


### PR DESCRIPTION
If the options for a Spinner are declared as data attributes, the data attributes are only used during instantiation if the Spinner is initialised via the user performing a mousedown event on the element (data attributes API).

If you call a Spinner method on an element prior to instantiation, the Spinner will get instantiated but the data attributes aren't passed through.

I have a use case where my Spinner starts off in a disabled state, and I enable it later if the user performs a certain action.  In this case, the `data-min` and `data-max` values from my markup don't get applied because the call to `disable` initialises the Spinner without using the data attributes.  Then, when I enable the Spinner later, I am able to go below `data-min` and above `data-max` (the default limits of `1` and `999` are applied instead).    [This JSFiddle](http://jsfiddle.net/warby_/6h4upxot/1/) demonstrates the issue.  I haven't checked to see if any of the other plugins have the same issue.