### PR TITLE
Checkbox no-js styling with box-shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,12 +310,33 @@
 						<div class="input-group">
 							<span class="input-group-addon">
 								<span class="checkbox-inline">
-									<input type="checkbox" id="example-checkbox-addon" value="">
+									<input type="checkbox" id="example-checkbox-addon" checked="checked" value="">
 									<label for="example-checkbox-addon"></label>
 								</span>
 							</span>
 							<input type="text" class="form-control" value="Checkbox within input add-on">
 						</div><!-- /input-group -->
+					</section>
+				</section>
+
+				<section id="checkbox-no-js-multiline" class="x-panel x-panel-default">
+					<header class="hidden x-panel-heading">
+						<h3 class="panel-title">Checkbox (no javascript) Checkbox with multiple line label</h3>
+					</header>
+					<section class="x-panel-body">
+
+						<form class="form-horizontal">
+							<div class="form-group">
+								<div class="checkbox multiline">
+									<input type="checkbox" id="checkboxes-no-js-multiline" name="checkboxes-no-js-multiline" checked="checked" value="">
+									<label for="checkboxes-no-js-multiline"></label>
+								</div>
+								<div class="control-label">
+									<label for="checkboxes-no-js-multiline">Have you eaten an african cherry orange, bilberry, ceylon gooseberry, dead man's fingers, or a governor’s plum?</label>
+								</div>
+							</div>
+						</form>
+
 					</section>
 				</section>
 
@@ -986,6 +1007,37 @@
 					</section>
 				</section>
 
+
+				<section id="radio-no-js-multiline" class="x-panel x-panel-default">
+					<header class="hidden x-panel-heading">
+						<h3 class="panel-title">Radio Buttons (no javascript) Radio button with multiline label</h3>
+					</header>
+					<section class="x-panel-body">
+
+						<form class="form-horizontal">
+							<div class="form-group">
+								<div class="radio multiline">
+									<input type="radio" id="radio-no-js-multiline--1" name="radio-no-js-multiline" value="">
+									<label for="radio-no-js-multiline--1"></label>
+								</div>
+								<div class="control-label">
+									<label for="radio-no-js-multiline--1">Have you eaten an african cherry orange, bilberry, ceylon gooseberry, dead man's fingers, or a governor’s plum?</label>
+								</div>
+							</div>
+							<div class="form-group">
+								<div class="radio multiline">
+									<input type="radio" id="radio-no-js-multiline--2" name="radio-no-js-multiline" value="">
+									<label for="radio-no-js-multiline--2"></label>
+								</div>
+								<div class="control-label">
+									<label for="radio-no-js-multiline--2">How about an apple?</label>
+								</div>
+							</div>
+						</form>
+
+					</section>
+				</section>
+
 				<section id="radiobuttons-no-js-inline-highlighting" class="x-panel x-panel-default">
 					<header class="hidden x-panel-heading">
 						<h3 class="panel-title">Radio Buttons (no javascript) Inline Highlighting</h3>
@@ -993,28 +1045,28 @@
 					<section class="x-panel-body">
 
 						<div class="radio-inline highlight">
-							<input type="radio" id="radiobuttons-no-js-inline-highlighting--1" name="radiobuttons-no-js-inline-highlighting" checked="checked" value="">
+							<input type="radio" id="radiobuttons-no-js-inline-highlighting--1" name="radiobuttons-no-js-inline-highlighting--1" checked="checked" value="">
 							<label for="radiobuttons-no-js-inline-highlighting--1">
 								1, 2, buckle my shoe
 							</label>
 						</div>
 
 						<div class="radio-inline highlight">
-							<input type="radio" id="radiobuttons-no-js-inline-highlighting--2" name="radiobuttons-no-js-inline-highlighting" value="">
+							<input type="radio" id="radiobuttons-no-js-inline-highlighting--2" name="radiobuttons-no-js-inline-highlighting--1" value="">
 							<label for="radiobuttons-no-js-inline-highlighting--2">
 								3, 4, shut the door
 							</label>
 						</div>
 
 						<div class="radio-inline highlight">
-							<input type="radio" id="radiobuttons-no-js-inline-highlighting--3" name="radiobuttons-no-js-inline-highlighting" checked="checked" disabled="disabled" value="">
+							<input type="radio" id="radiobuttons-no-js-inline-highlighting--3" name="radiobuttons-no-js-inline-highlighting--2" checked="checked" disabled="disabled" value="">
 							<label for="radiobuttons-no-js-inline-highlighting--3">
 								5, 6, pick up sticks
 							</label>
 						</div>
 
 						<div class="radio-inline highlight">
-							<input type="radio" id="radiobuttons-no-js-inline-highlighting--4" name="radiobuttons-no-js-inline-highlighting" disabled="disabled" value="">
+							<input type="radio" id="radiobuttons-no-js-inline-highlighting--4" name="radiobuttons-no-js-inline-highlighting--2" disabled="disabled" value="">
 							<label for="radiobuttons-no-js-inline-highlighting--4">
 								7, 8, lay them straight
 							</label>

--- a/less/checkbox-no-js.less
+++ b/less/checkbox-no-js.less
@@ -1,3 +1,5 @@
+@import "forms.less";
+
 .checkbox, .checkbox-inline {
 	
 	input[type="checkbox"]:not(.sr-only) {

--- a/less/forms.less
+++ b/less/forms.less
@@ -1,22 +1,16 @@
-.checkbox-radio-focus() {
-	box-shadow: inset 0px 0px 2px 1px rgba(91, 157, 217, .9), 0px 0px 5px 0px rgba(91, 157, 217, .9);
+.checkbox-radio-hover() {
+	box-shadow: inset 0px 0px 2px 1px rgba(91, 157, 217, .7), 0px 0px 5px 0px rgba(91, 157, 217, .7);
 }
 
-.labelHover() {
-	&:hover {
-		// color: @grayLight;
-	}
+.checkbox-radio-focus() {
+	box-shadow: inset 0px 0px 2px 1px rgb(91, 157, 217), 0px 0px 5px 0px rgb(91, 157, 217);
 }
 
 .radio, .checkbox {
-		// text-indent: -20px;
-		// padding-left: 40px;
 
 	&-inline {
-		// text-indent: 0px;
-		// margin-left: 0px;
-
 		padding-left: 0;
+
 		&.highlight {
 			left: -8px;
 		}
@@ -34,13 +28,14 @@
 		// Sometimes the label itself is the wrapping container, and has .checkbox or .radio on it.
 		// The use of the amperstand "parent selector" here allows us to cover many scenarios at once, with terse, but elegant, code.
 		label&, .input-label&, & label, & .input-label {
-			.labelHover;
+			&:hover:before {
+				.checkbox-radio-hover();
+			}
 		}
 		
 		label, .input-label, label& {
 			cursor: pointer;
 			font-weight: normal;
-			.labelHover;
 		}
 
 		&.highlight {
@@ -89,6 +84,7 @@
 					margin-bottom: -2px;
 					cursor: pointer;
 					display: inline-block;
+					text-align: left;
 					z-index: 2;
 					content: "";
 				}
@@ -106,10 +102,6 @@
 				&:before {
 					.checkbox-radio-focus();
 					outline: none;
-					// outline-color: rgb(91, 157, 217);
-					// outline-offset: -2px;
-					// outline-style: auto;
-					// outline-width: 5px;
 				}
 
 				&, &:hover {
@@ -146,14 +138,6 @@
 
 		}
 
-		&, &:hover {
-			input {
-				&:checked {
-
-				}
-			}
-		}
-
 		&.highlight {
 			&:before {
 				left: 4px;
@@ -185,3 +169,25 @@
 	}
 
 }
+
+
+
+// Allows multiline labels next to checkboxes and radio 
+// Should be wrapped in `<form class="form-horizontal"><div class="form-group">`
+.checkbox.multiline, .radio.multiline {
+	float: left; 
+	margin-left: 15px;
+}
+
+.checkbox.multiline ~ .control-label, .radio.multiline ~ .control-label {
+	float: left; 
+	width: 80%; 
+	margin-left: 10px; 
+	text-align: left;
+
+	& > label {
+		font-weight: normal;
+		cursor: pointer;
+	}
+}
+

--- a/less/forms.less
+++ b/less/forms.less
@@ -1,11 +1,21 @@
+.checkbox-radio-focus() {
+	box-shadow: inset 0px 0px 2px 1px rgba(91, 157, 217, .9), 0px 0px 5px 0px rgba(91, 157, 217, .9);
+}
+
 .labelHover() {
 	&:hover {
-		color: @grayLight;
+		// color: @grayLight;
 	}
 }
 
 .radio, .checkbox {
+		// text-indent: -20px;
+		// padding-left: 40px;
+
 	&-inline {
+		// text-indent: 0px;
+		// margin-left: 0px;
+
 		padding-left: 0;
 		&.highlight {
 			left: -8px;
@@ -94,10 +104,12 @@
 				cursor: pointer;
 				
 				&:before {
-					outline-color: rgb(91, 157, 217);
-					outline-offset: -2px;
-					outline-style: auto;
-					outline-width: 5px;
+					.checkbox-radio-focus();
+					outline: none;
+					// outline-color: rgb(91, 157, 217);
+					// outline-offset: -2px;
+					// outline-style: auto;
+					// outline-width: 5px;
 				}
 
 				&, &:hover {
@@ -120,6 +132,8 @@
 					color: @text-color;
 					opacity: 0.5 !important;
 					cursor: not-allowed !important;
+					outline: none;
+					box-shadow: none;
 				}
 			}
 

--- a/less/radio-no-js.less
+++ b/less/radio-no-js.less
@@ -1,3 +1,5 @@
+@import "forms.less";
+
 .radio, .radio-inline {
 	
 	input[type="radio"]:not(.sr-only) {
@@ -26,16 +28,11 @@
 		}
 
 
-
-
 		/* for keyboard tabbing */
 		&:hover ~ label, &:active ~ label, &:focus ~ label {
 		
 			&:before {
-				outline-color: rgba(91, 157, 217, 0.7);
-				outline-offset: -4px;
-				outline-style: auto;
-				outline-width: 6px;
+				.checkbox-radio-focus();
 			}
 
 		}


### PR DESCRIPTION
Overview: 
- Hover/active outline styling removed and replaced with inset and outset double box-shadow
- Text color change on hover has been removed, now that a hover effect exists for the checkbox/radio.

Fixes for #1180:
-  Disabled checkbox (no-JS) no long has a hover effect.-. Outline has not been removed, but replaced with box-shadow affect.
- Box-shadow is now very similar to Mac UI effect.
- Disabled radio (no-JS) no long has a hover effect.
- "Block indention" cannot be fixed within current setup of "label:before backgrounds masquerading as checkboxen and radios." Solution was to add the multiline style to checkbox and radio to allow a "column-like" float. This setup **expects** to be wrapped in 						`<form class="form-horizontal"><div class="form-group">` or similar container with negative margins. **Please note duplicate labels** that point to same input id. This is permissible, although I am unsure of how affects accessibility. 

Partially fixes https://github.com/ExactTarget/fuelux-mctheme/issues/207 in MCtheme.
- Remove hover color change on label now that there is a hover effect on icon
- Needs visual change on focus (via keyboard, tabbing)

Examples of multiline checkbox and radio markup using [Bootstrap's form-horizontal paradigm](http://getbootstrap.com/css/#forms-horizontal).
```
<form class="form-horizontal">
  <div class="form-group">
    <div class="checkbox multiline">
      <input type="checkbox" id="checkboxes-no-js-multiline" name="checkboxes-no-js-multiline" value="">
      <label for="checkboxes-no-js-multiline"></label>
    </div>
    <div class="control-label">
      <label for="checkboxes-no-js-multiline">Have you eaten an african cherry orange, bilberry, ceylon gooseberry, dead man's fingers, or a governor’s plum?</label>
    </div>
  </div>
</form>
```

```
<form class="form-horizontal">
  <div class="form-group">
    <div class="radio multiline">
      <input type="radio" id="radio-no-js-multiline--1" name="radio-no-js-multiline" value="">
      <label for="radio-no-js-multiline--1"></label>
    </div>
    <div class="control-label">
      <label for="radio-no-js-multiline--1">Have you eaten an african cherry orange, bilberry, ceylon gooseberry, dead man's fingers, or a governor’s plum?</label>
    </div>
  </div>
</form>
```

Possible accessibility issues? According to [this article from 2008](http://www.456bereastreet.com/archive/200809/multiple_form_labels_and_screen_readers/):

> Apple VoiceOver does not recognise more than one label element associated with a form control and reads only the label that comes first in the document’s source order.
> JAWS and Window-Eyes both do the opposite and read only the last label when an input field gains focus.
> The only screen reader of those that I tested that does handle multiple labels is Fire Vox.