### PR TITLE
Remove Creator section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ Our aim is to provide a suite of related but independent projects that help web 
 |Stephen Williams | [![swilliamsui on Twitter](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertobird-sm.png)](http://twitter.com/swilliamsui) [![swilliamset on Github](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertocat-sm.png)](http://github.com/swilliamset)|
 |Dave Woodward | [![futuremint on Twitter](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertobird-sm.png)](http://twitter.com/futuremint) [![futuremint on Github](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertocat-sm.png)](http://github.com/futuremint)|
 
-|Creator | |
-|:----|----:|
-|Adam Alexander | [![adamalex on Twitter](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertobird-sm.png)](http://twitter.com/adamalex) [![adamalex on Github](https://raw.githubusercontent.com/ExactTarget/fuelux/gh-pages/invertocat-sm.png)](http://github.com/adamalex) |
-
 Special thanks to [major contributors](https://github.com/exacttarget/fuelux/blob/master/DETAILS.md#contributors) and [active contributors](https://github.com/ExactTarget/fuelux/graphs/contributors).
 
 And thank you to all those that have submitted issues and contributed to this library.


### PR DESCRIPTION
I may have created the repository but you have all long surpassed the contributions I've made, and Fuel UX is a much bigger deal than I could have ever imagined! I appreciate the team leaving this credit in place for so long. This seems like as good a time as any to retire this section from the README.