### PR TITLE
Repeater disabling methods

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -231,7 +231,7 @@
 		enable: function() {
 			var disabled = 'disabled';
 			var enable = 'enable';
-			var noMore = 'no-more';
+			var pageEnd = 'page-end';
 
 			this.$search.search(enable);
 			this.$filters.selectlist(enable);
@@ -240,10 +240,10 @@
 			this.$primaryPaging.find('.combobox').combobox(enable);
 			this.$secondaryPaging.removeAttr(disabled);
 
-			if(!this.$prevBtn.hasClass(noMore)){
+			if(!this.$prevBtn.hasClass(pageEnd)){
 				this.$prevBtn.removeAttr(disabled);
 			}
-			if(!this.$nextBtn.hasClass(noMore)){
+			if(!this.$nextBtn.hasClass(pageEnd)){
 				this.$nextBtn.removeAttr(disabled);
 			}
 
@@ -439,8 +439,8 @@
 		pagination: function (data) {
 			var act = 'active';
 			var dsbl = 'disabled';
-			var noMore = 'no-more';
 			var page = data.page;
+			var pageEnd = 'page-end';
 			var pages = data.pages;
 			var dropMenu, i, l;
 
@@ -470,19 +470,19 @@
 			// this is not the last page
 			if ((this.currentPage + 1) < pages) {
 				this.$nextBtn.removeAttr(dsbl);
-				this.$nextBtn.removeClass(noMore);
+				this.$nextBtn.removeClass(pageEnd);
 			} else {
 				this.$nextBtn.attr(dsbl, dsbl);
-				this.$nextBtn.addClass(noMore);
+				this.$nextBtn.addClass(pageEnd);
 			}
 
 			// this is not the first page
 			if ((this.currentPage - 1) >= 0) {
 				this.$prevBtn.removeAttr(dsbl);
-				this.$prevBtn.removeClass(noMore);
+				this.$prevBtn.removeClass(pageEnd);
 			} else {
 				this.$prevBtn.attr(dsbl, dsbl);
-				this.$prevBtn.addClass(noMore);
+				this.$prevBtn.addClass(pageEnd);
 			}
 
 			// return focus to next/previous buttons after navigating

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -224,6 +224,7 @@
 			this.$prevBtn.attr(disabled, disabled);
 			this.$nextBtn.attr(disabled, disabled);
 
+			this.$element.addClass('disabled');
 			this.$element.trigger('disabled.fu.repeater');
 		},
 
@@ -246,6 +247,7 @@
 				this.$nextBtn.removeAttr(disabled);
 			}
 
+			this.$element.removeClass('disabled');
 			this.$element.trigger('enabled.fu.repeater');
 		},
 

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -211,6 +211,44 @@
 			return markup;
 		},
 
+		disable: function() {
+			var disable = 'disable';
+			var disabled = 'disabled';
+
+			this.$search.search(disable);
+			this.$filters.selectlist(disable);
+			this.$views.find('label').attr(disabled, disabled);
+			this.$pageSize.selectlist(disable);
+			this.$primaryPaging.find('.combobox').combobox(disable);
+			this.$secondaryPaging.attr(disabled, disabled);
+			this.$prevBtn.attr(disabled, disabled);
+			this.$nextBtn.attr(disabled, disabled);
+
+			this.$element.trigger('disabled.fu.repeater');
+		},
+
+		enable: function() {
+			var disabled = 'disabled';
+			var enable = 'enable';
+			var noMore = 'no-more';
+
+			this.$search.search(enable);
+			this.$filters.selectlist(enable);
+			this.$views.find('label').removeAttr(disabled);
+			this.$pageSize.selectlist('enable');
+			this.$primaryPaging.find('.combobox').combobox(enable);
+			this.$secondaryPaging.removeAttr(disabled);
+
+			if(!this.$prevBtn.hasClass(noMore)){
+				this.$prevBtn.removeAttr(disabled);
+			}
+			if(!this.$nextBtn.hasClass(noMore)){
+				this.$nextBtn.removeAttr(disabled);
+			}
+
+			this.$element.trigger('enabled.fu.repeater');
+		},
+
 		getDataOptions: function (options) {
 			var dataSourceOptions = {};
 			var opts = {};
@@ -399,6 +437,7 @@
 		pagination: function (data) {
 			var act = 'active';
 			var dsbl = 'disabled';
+			var noMore = 'no-more';
 			var page = data.page;
 			var pages = data.pages;
 			var dropMenu, i, l;
@@ -429,15 +468,19 @@
 			// this is not the last page
 			if ((this.currentPage + 1) < pages) {
 				this.$nextBtn.removeAttr(dsbl);
+				this.$nextBtn.removeClass(noMore);
 			} else {
 				this.$nextBtn.attr(dsbl, dsbl);
+				this.$nextBtn.addClass(noMore);
 			}
 
 			// this is not the first page
 			if ((this.currentPage - 1) >= 0) {
 				this.$prevBtn.removeAttr(dsbl);
+				this.$prevBtn.removeClass(noMore);
 			} else {
 				this.$prevBtn.attr(dsbl, dsbl);
+				this.$prevBtn.addClass(noMore);
 			}
 
 			// return focus to next/previous buttons after navigating
@@ -481,6 +524,7 @@
 			var dataOptions, prevView;
 
 			options = options || {};
+			this.disable();
 
 			if (options.changeView && (this.currentView !== options.changeView)) {
 				prevView = this.currentView;
@@ -543,6 +587,8 @@
 
 					//for maintaining support of 'loaded' event
 					self.$element.trigger('loaded.fu.repeater', dataOptions);
+
+					self.enable();
 				});
 			});
 		},

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -288,6 +288,59 @@ define(function(require){
 		});
 	});
 
+	test("should handle disable / enable correctly", function () {
+		var $repeater = $(this.$markup);
+
+		var $search = $repeater.find('.repeater-header .search');
+		var $filters = $repeater.find('.repeater-header .repeater-filters');
+		var $views = $repeater.find('.repeater-header .repeater-views label');
+		var $pageSize = $repeater.find('.repeater-footer .repeater-itemization .selectlist');
+		var $primaryPaging = $repeater.find('.repeater-footer .repeater-primaryPaging .combobox');
+		var $secondaryPaging = $repeater.find('.repeater-footer .repeater-secondaryPaging');
+		var $prevBtn = $repeater.find('.repeater-prev');
+		var $nextBtn = $repeater.find('.repeater-next');
+
+		var disabled = 'disabled';
+
+		$repeater.on('disabled.fu.repeater', function(){
+			ok(1===1, 'disabled event called as expected');
+		});
+
+		$repeater.on('enabled.fu.repeater', function(){
+			ok(1===1, 'enabled event called as expected');
+		});
+
+		$repeater.on('rendered.fu.repeater', function(){
+			setTimeout(function(){
+				$repeater.repeater('disable');
+
+				equal($search.hasClass(disabled), true, 'repeater search disabled as expected');
+				equal($filters.hasClass(disabled), true, 'repeater filters disabled as expected');
+				equal($views.attr(disabled), disabled, 'repeater views disabled as expected');
+				equal($pageSize.hasClass(disabled), true, 'repeater pageSize disabled as expected');
+				equal($primaryPaging.hasClass(disabled), true, 'repeater primaryPaging disabled as expected');
+				equal($secondaryPaging.attr(disabled), disabled, 'repeater secondaryPaging disabled as expected');
+				equal($prevBtn.attr(disabled), disabled, 'repeater prevBtn disabled as expected');
+				equal($nextBtn.attr(disabled), disabled, 'repeater nextBtn disabled as expected');
+				equal($repeater.hasClass(disabled), true, 'repeater has disabled class as expected');
+
+				$repeater.repeater('enable');
+
+				equal($search.hasClass(disabled), false, 'repeater search enabled as expected');
+				equal($filters.hasClass(disabled), false, 'repeater filters enabled as expected');
+				equal($views.attr(disabled), undefined, 'repeater views enabled as expected');
+				equal($pageSize.hasClass(disabled), false, 'repeater pageSize enabled as expected');
+				equal($primaryPaging.hasClass(disabled), false, 'repeater primaryPaging enabled as expected');
+				equal($secondaryPaging.attr(disabled), undefined, 'repeater secondaryPaging enabled as expected');
+				equal($prevBtn.attr(disabled), disabled, 'repeater prevBtn still disabled as expected (no more pages)');
+				equal($nextBtn.attr(disabled), disabled, 'repeater nextBtn still disabled as expected (no more pages)');
+
+				equal($repeater.hasClass(disabled), false, 'repeater no longer has disabled class as expected');
+			}, 0);
+		});
+		$repeater.repeater();
+	});
+
 	asyncTest('should destroy control', function(){
 		var $repeater = $(this.$markup);
 


### PR DESCRIPTION
Fixes #1212 by adding a disable and enable method, which disables/enables default repeater header and footer controls when called. Additionally, these methods are called prior to rendering and after render completion. Events are thrown within these methods for plugin and app timing purposes.