### PR TITLE
Remove `cursor: pointer` CSS rule from Datagrid <th> elements

### DIFF
--- a/src/less/datagrid.less
+++ b/src/less/datagrid.less
@@ -2,10 +2,6 @@
 
 .datagrid {
 
-	th {
-		cursor: pointer;
-	}
-
 	thead {
 
 		background-color: @tableBackgroundAccent;


### PR DESCRIPTION
Commit `36f77bb7`, which added support for selectable rows in the Datagrid component also added a `th { cursor: pointer }` CSS rule.  This rule makes the cursor style incorrect when hovering over the datagrid header and footer:

![issue-th-cursor](https://cloud.githubusercontent.com/assets/617098/7151888/d64b72b6-e363-11e4-8ffe-e02cdb13ec01.png)

This fix removes that CSS rule.  I've checked that all of the controls in the header/footer still get the pointer cursor as expected.  The cursor when hovering over a row when the `enableSelect` option is set to `true` is also still a pointer as expected.

