### PR TITLE
Add AMD bundle to dist build

### DIFF
--- a/grunt/fuelux-bundled-amd.js
+++ b/grunt/fuelux-bundled-amd.js
@@ -1,0 +1,13 @@
+/*
+ * Fuel UX Bundled AMD (Require.JS, jQuery, Bootstrap, Moment.js and Fuel UX)
+ * https://github.com/ExactTarget/fuelux
+ *
+ * Copyright (c) 2015 ExactTarget
+ * Licensed under the BSD New license.
+ *
+ * NOTE: This file works with AMD only.
+ */
+
+define(['require', 'jquery', 'bootstrap', 'moment', 'fuelux'], function() {
+	// empty
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-jshint": "0.x",
     "grunt-contrib-less": "1.x",
     "grunt-contrib-qunit": "0.5.x",
+    "grunt-contrib-requirejs": "0.x",
     "grunt-contrib-uglify": "0.x",
     "grunt-contrib-watch": "0.x",
     "grunt-html-validation": "0.x",

--- a/test/tests-bundled-amd.html
+++ b/test/tests-bundled-amd.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>FuelUX Component Initialization (Bundled AMD)</title>
+		<link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css" media="screen">
+		<link href="../bower_components/bootstrap/dist/css/bootstrap.css" rel="stylesheet" type="text/css">
+		<link href="../dist/css/fuelux.css" rel="stylesheet" type="text/css">
+
+		<script src="../bower_components/qunit/qunit/qunit.js"></script>
+		<script>QUnit.config.autostart = false;</script>
+
+		<!-- bundled JS file -->
+		<script src="../dist/js/fuelux-bundled-amd.js"></script>
+
+		<script type="text/javascript">
+			(function () {
+				requirejs.config({
+					baseUrl: '../',
+					config: {
+						moment: {
+							noGlobal: true
+						}
+					},
+					paths: {
+						jquery: 'dist/js/fuelux-bundled-amd',
+						// underscore: 'bower_components/underscore/underscore',
+						bootstrap: 'dist/js/fuelux-bundled-amd',
+						moment: 'dist/js/fuelux-bundled-amd',
+						fuelux: 'dist/js/fuelux-bundled-amd',
+						'fuelux-bundled-amd': 'dist/js/fuelux-bundled-amd',
+						tests: 'test/tests-bundled-amd',
+						text: 'bower_components/requirejs-text/text'
+					},
+					map: {
+						'*': {
+							'fuelux/checkbox': 'dist/js/fuelux-bundled-amd',
+							'fuelux/combobox': 'dist/js/fuelux-bundled-amd',
+							'fuelux/datepicker': 'dist/js/fuelux-bundled-amd',
+							'fuelux/dropdown-autoflip': 'dist/js/fuelux-bundled-amd',
+							'fuelux/infinite-scroll': 'dist/js/fuelux-bundled-amd',
+							'fuelux/loader': 'dist/js/fuelux-bundled-amd',
+							'fuelux/pillbox': 'dist/js/fuelux-bundled-amd',
+							'fuelux/placard': 'dist/js/fuelux-bundled-amd',
+							'fuelux/radio': 'dist/js/fuelux-bundled-amd',
+							'fuelux/repeater-list': 'dist/js/fuelux-bundled-amd',
+							'fuelux/repeater-thumbnail': 'dist/js/fuelux-bundled-amd',
+							'fuelux/repeater': 'dist/js/fuelux-bundled-amd',
+							'fuelux/scheduler': 'dist/js/fuelux-bundled-amd',
+							'fuelux/search': 'dist/js/fuelux-bundled-amd',
+							'fuelux/selectlist': 'dist/js/fuelux-bundled-amd',
+							'fuelux/spinbox': 'dist/js/fuelux-bundled-amd',
+							'fuelux/tree': 'dist/js/fuelux-bundled-amd',
+							'fuelux/wizard': 'dist/js/fuelux-bundled-amd'
+						}
+					}
+				});
+
+				
+			})();
+
+			// the following are the same as tests.js
+			require(['fuelux-bundled-amd', 
+							'./test/checkbox-test', 
+							'./test/combobox-test', 
+							'./test/datepicker-moment-test', 
+							'./test/infinite-scroll-test',
+							'./test/loader-test',
+							'./test/pillbox-test',
+							'./test/placard-test',
+							'./test/radio-test',
+							'./test/repeater-test',
+							'./test/repeater-list-test',
+							'./test/repeater-thumbnail-test',
+							'./test/scheduler-test',
+							'./test/search-test',
+							'./test/selectlist-test',
+							'./test/spinbox-test',
+							'./test/tree-test',
+							'./test/wizard-test'
+							], function(){ 
+
+					QUnit.start(); // starting qunit, or phantom js will have a problem
+					
+					// Needed for saucelab testing
+					var log = [];
+					var testName;
+
+					QUnit.done(function (test_results) {
+						var tests = [];
+						for(var i = 0, len = log.length; i < len; i++) {
+							var details = log[i];
+							tests.push({
+								name: details.name,
+								result: details.result,
+								expected: details.expected,
+								actual: details.actual,
+								source: details.source
+							});
+						}
+						test_results.tests = tests;
+
+						window.global_test_results = test_results;
+
+					// hide passed tests, helps with VM testing screencasts
+					if (!$('#qunit-filter-pass').is(':checked')) {
+						$('#qunit-filter-pass').click();
+					}
+
+					});
+					QUnit.testStart(function(testDetails){
+						QUnit.log = function(details){
+							if (!details.result) {
+								details.name = testDetails.name;
+								log.push(details);
+							}
+						};
+					});
+
+			 });
+		</script>
+
+	</head>
+	<body class="fuelux">
+		<h1 id="qunit-header">Fuel UX (Bundled AMD) Initialization Test Suite</h1>
+
+		<h2 id="qunit-banner"></h2>
+
+		<div id="qunit-testrunner-toolbar"></div>
+		<h2 id="qunit-userAgent"></h2>
+		<ol id="qunit-tests"></ol>
+		<div id="qunit-fixture"></div>
+
+		<!-- Test -->
+		
+		<!-- <script src="browser-globals.js"></script> -->
+
+	</body>
+</html>

--- a/test/tests-bundled-amd.js
+++ b/test/tests-bundled-amd.js
@@ -1,0 +1,69 @@
+/*global QUnit:false, module:false, test:false, asyncTest:false, expect:false*/
+/*global start:false, stop:false ok:false, equal:false, notEqual:false, deepEqual:false*/
+/*global notDeepEqual:false, strictEqual:false, notStrictEqual:false, raises:false*/
+
+define(function(require){
+console.log('test');
+	var $ = require('jquery');
+
+	console.log('test');
+
+	QUnit.start(); // starting qunit, or phantom js will have a problem
+	
+	// Needed for saucelab testing
+	var log = [];
+	var testName;
+
+	QUnit.done(function (test_results) {
+		var tests = [];
+		for(var i = 0, len = log.length; i < len; i++) {
+			var details = log[i];
+			tests.push({
+				name: details.name,
+				result: details.result,
+				expected: details.expected,
+				actual: details.actual,
+				source: details.source
+			});
+		}
+		test_results.tests = tests;
+
+		window.global_test_results = test_results;
+
+	// hide passed tests, helps with VM testing screencasts
+	if (!$('#qunit-filter-pass').is(':checked')) {
+		$('#qunit-filter-pass').click();
+	}
+
+	});
+	QUnit.testStart(function(testDetails){
+		QUnit.log = function(details){
+			if (!details.result) {
+				details.name = testDetails.name;
+				log.push(details);
+			}
+		};
+	});
+
+console.log('test');
+
+	require('moment');
+	require('./test/checkbox-test');
+	require('./test/combobox-test');
+	require('./test/datepicker-moment-test');
+	require('./test/infinite-scroll-test');
+	require('./test/loader-test');
+	require('./test/pillbox-test');
+	require('./test/placard-test');
+	require('./test/radio-test');
+	require('./test/repeater-test');
+	require('./test/repeater-list-test');
+	require('./test/repeater-thumbnail-test');
+	require('./test/scheduler-test');
+	require('./test/search-test');
+	require('./test/selectlist-test');
+	require('./test/spinbox-test');
+	require('./test/tree-test');
+	require('./test/wizard-test');
+
+});


### PR DESCRIPTION
This adds a mangled JS file to the `dist/js` folder which contains Fuel UX Bundled AMD (Require.JS, jQuery, Bootstrap, Moment.js and Fuel UX). 

Approx. size when gzipped: 124KB.

Testing task (qunit:validate-distBundledAMD) has also been added to double check that concatenating and mangling does not break anything. Same actual control tests are being used. This test runs on release.

It also includes a module/define name called `fuelux-bundled-amd` for convenience for those developers that don't like a lot of typing.