### PR TITLE
Allow repeater to scroll when needed

### DIFF
--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -1,18 +1,20 @@
 .repeater[data-viewtype="list"] {
-	.repeater-canvas.scrolling {
-		overflow: visible;
+	.repeater-canvas {
+		&.scrolling {
+			overflow: visible;
 
-		.repeater-list {
-			bottom: 0;
-			left: 0;
-			position: absolute;
-			right: 0;
-			top: 0;
-		}
+			.repeater-list {
+				bottom: 0;
+				left: 0;
+				position: absolute;
+				right: 0;
+				top: 0;
+			}
 
-		.repeater-list-wrapper {
-			height: 100%;
-			overflow: auto;
+			.repeater-list-wrapper {
+				height: 100%;
+				overflow: auto;
+			}
 		}
 
 		.repeater-list {


### PR DESCRIPTION
Everything was wrapped in .scrolling on the canvas. When the repeater actually needed to scroll it was being overwritten because .scrolling was not being called correctly. Issue that came from my changes for frozen columns.

Fixes #1254 and #1253 