### PR TITLE
Wizard Docs Fix

### DIFF
--- a/_includes/js/wizard.html
+++ b/_includes/js/wizard.html
@@ -20,7 +20,9 @@
   <p>Wrap <code>class="wizard"</code> around a list of steps, navigation, and content within a <code>class="fuelux"</code> container.</p>
   <div class="truncate-highlight">
 {% highlight html %}
+<div class="wizard" data-initialize="wizard" id="myWizard">
 {% include js/wizard-example.html %}
+</div>
 {% endhighlight %}
   </div>
 


### PR DESCRIPTION
Fixes #1260 by making the markup section of wizard have the control parent wrapper.