### PR TITLE
Revert breaking checkbox markup change for 3.7.2 release

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
 	<script type="text/javascript">if(window.console && window.console.clear){ window.console.clear(); }</script>
 
 	<link href="index.css" rel="stylesheet" type="text/css">
-	<!--<link href="http://www.fuelcdn.com/fuelux-mctheme/1.4.0/css/fuelux-mctheme.css" rel="stylesheet" type="text/css" />-->
 
 	<script src="bower_components/requirejs/require.js"></script>
 	<script type="text/javascript">
@@ -53,97 +52,97 @@
 			<div class="thin-box">
 
 				<section id="checkboxes-block">
-
-					<div class="checkbox">
-						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomCheckbox1">
-							<input type="checkbox" class="sr-only">
-							Custom checkbox unchecked on page load
+					<div class="checkbox" data-initialize="checkbox">
+						<label class="checkbox-custom"  id="myCustomCheckbox1">
+							<input class="sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox unchecked on page load</span>
 						</label>
 					</div>
-					<div class="checkbox">
-						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomCheckbox2">
-							<input type="checkbox" class="sr-only" checked="checked">
-							Highlight Custom checkbox checked on page load
+					<div class="checkbox" data-initialize="checkbox">
+						<label class="checkbox-custom"  id="myCustomCheckbox2">
+							<input checked="checked" class="checked sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox checked on page load</span>
 						</label>
 					</div>
-					<div class="checkbox">
-						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomCheckbox3">
-							<input type="checkbox" class="sr-only" disabled="disabled">
-							Custom checkbox disabled and unchecked on page load
+					<div class="checkbox" data-initialize="checkbox">
+						<label class="checkbox-custom"  id="myCustomCheckbox3">
+							<input class="sr-only" disabled="disabled" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox disabled and unchecked on page load</span>
 						</label>
 					</div>
-					<div class="checkbox">
-						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomCheckbox4">
-							<input type="checkbox" class="sr-only" checked="checked" disabled="disabled">
-							Custom checkbox disabled and checked on page load
+					<div class="checkbox" data-initialize="checkbox">
+						<label class="checkbox-custom"  id="myCustomCheckbox4">
+							<input checked="checked" class="checked sr-only" disabled="disabled" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox disabled and checked on page load</span>
 						</label>
 					</div>
 				</section>
 
+
 				<section id="checkboxes-inline">
 					<label class="checkbox-custom checkbox-inline" data-initialize="checkbox" id="myCustomInlineCheckbox1">
-						<input type="checkbox" class="sr-only" checked="checked">1, 2, buckle my shoe
+						<input checked="checked" class="checked sr-only" type="checkbox" value=""> <span class="checkbox-label">1, 2, buckle my shoe</span>
 					</label>
 					<label class="checkbox-custom checkbox-inline" data-initialize="checkbox" id="myCustomInlineCheckbox2">
-						<input type="checkbox" class="sr-only">3, 4, shut the door
+						<input class="sr-only" type="checkbox" value=""> <span class="checkbox-label">3, 4, shut the door</span>
 					</label>
 					<label class="checkbox-custom checkbox-inline" data-initialize="checkbox" id="myCustomInlineCheckbox3">
-						<input type="checkbox" class="sr-only" disabled="disabled">5, 6, pick up sticks
+						<input class="sr-only" disabled="disabled" type="checkbox" value=""> <span class="checkbox-label">5, 6, pick up sticks</span>
 					</label>
 					<label class="checkbox-custom checkbox-inline" data-initialize="checkbox" id="myCustomInlineCheckbox4">
-						<input type="checkbox" class="checked sr-only" checked="checked" disabled="disabled">7, 8, lay them straight
+						<input checked="checked" class="checked sr-only" disabled="disabled" type="checkbox" value=""> <span class="checkbox-label">7, 8, lay them straight</span>
 					</label>
 				</section>
 
 				<section id="checkboxes-toggling">
 					<div class="checkbox">
 						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomTogglingCheckbox1">
-							<input type="checkbox" class="sr-only" data-toggle=".checkboxToggle">
-							Custom checkbox toggles by class
+							<input class="sr-only" data-toggle=".checkboxToggle" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox toggles by class</span>
 						</label>
 					</div>
 					<div class="checkbox">
 						<label class="checkbox-custom" data-initialize="checkbox" id="myCustomTogglingCheckbox2">
-							<input type="checkbox" class="sr-only" data-toggle="#checkboxToggle">
-							Custom checkbox toggles by id
+							<input class="sr-only" data-toggle="#checkboxToggle" type="checkbox" value="">
+							<span class="checkbox-label">Custom checkbox toggles by id</span>
 						</label>
 					</div>
 					<div aria-hidden="true" class="checkboxToggle alert alert-warning hidden">This message's visibility toggles by class with a checkbox above.</div>
 					<div aria-hidden="true" class="checkboxToggle alert alert-success hidden">This message's visibility toggles by class with a checkbox above.</div>
 					<div aria-hidden="true" class="alert alert-info hidden" id="checkboxToggle">This message's visibility toggles by id with a checkbox above.</div>
 				</section>
-				<section id="checkboxes-highlighting-block"><!-- why duplicate the highlight classes on div.checkbox and label?, why span.checkbox-label vs. text node, why does checked input require 'checked' class too? -->
+				<section id="checkboxes-highlighting-block">
 					<div class="checkbox highlight">
 						<label class="checkbox-custom highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox1">
-							<input type="checkbox" class="sr-only">
-							Custom block-level highlight checkbox
+							<input class="sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom block-level highlight checkbox</span>
 						</label>
 					</div>
 					<div class="checkbox highlight">
 						<label class="checkbox-custom highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox2">
-							<input type="checkbox" class="sr-only">
-							Custom block-level highlight checkbox
+							<input class="sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom block-level highlight checkbox</span>
 						</label>
 					</div>
 					<div class="checkbox highlight">
 						<label class="checkbox-custom highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox3">
-							<input type="checkbox" class="sr-only">
-							Custom block-level highlight checkbox
+							<input class="sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom block-level highlight checkbox</span>
 						</label>
 					</div>
 					<div class="checkbox highlight">
 						<label class="checkbox-custom highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox4">
-							<input type="checkbox" class="sr-only">
-							Custom block-level highlight checkbox
+							<input class="sr-only" type="checkbox" value="">
+							<span class="checkbox-label">Custom block-level highlight checkbox</span>
 						</label>
 					</div>
 				</section>
 				<section id="checkboxes-highlighting-inline">
 					<label class="checkbox-custom checkbox-inline highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox5">
-						<input type="checkbox" class="sr-only">Custom inline highlight checkbox
+						<input class="sr-only" type="checkbox" value=""> <span class="checkbox-label">Custom inline highlight checkbox</span>
 					</label>
 					<label class="checkbox-custom checkbox-inline highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox6">
-						<input type="checkbox" class="sr-only">Custom inline highlight checkbox
+						<input class="sr-only" type="checkbox" value=""> <span class="checkbox-label">Custom inline highlight checkbox</span>
 					</label>
 				</section>
 			</div>
@@ -152,9 +151,6 @@
 				<button type="button" class="btn btn-default" id="btnCheckboxDisable">disable #myCustomCheckbox1</button>
 				<button type="button" class="btn btn-default" id="btnCheckboxEnable">enable #myCustomCheckbox1</button>
 				<button type="button" class="btn btn-default" id="btnCheckboxDestroy">destroy and append #myCustomCheckbox1</button>
-				<button type="button" class="btn btn-default" id="btnCheckboxIsChecked">is #myCustomCheckbox1 checked?</button>
-				<button type="button" class="btn btn-default" id="btnCheckboxCheck">check #myCustomCheckbox1</button>
-				<button type="button" class="btn btn-default" id="btnCheckboxUncheck">uncheck #myCustomCheckbox1</button>
 			</div>
 		</section>
 

--- a/index.js
+++ b/index.js
@@ -35,33 +35,17 @@ define(function (require) {
 		$('#myCustomCheckbox1').checkbox('enable');
 	});
 	$('#btnCheckboxDestroy').on('click', function () {
-		var $container = $('#myCustomCheckbox1').parent();
+		var $container = $('#myCustomCheckbox1').parents('.thin-box:first');
 		var markup = $('#myCustomCheckbox1').checkbox('destroy');
 		log(markup);
 		$container.append(markup);
 	});
-	$('#btnCheckboxIsChecked').on('click', function () {
-		var checked = $('#myCustomCheckbox1').checkbox('isChecked');
-		log(checked);
-	});
-	$('#btnCheckboxCheck').on('click', function () {
-		$('#myCustomCheckbox1').checkbox('check');
-	});
-	$('#btnCheckboxUncheck').on('click', function () {
-		$('#myCustomCheckbox1').checkbox('uncheck');
-	});
 
-	$('#myCustomCheckbox1').on('changed.fu.checkbox', function(evt, data) {
-		log('changed', data);
-	});
-	$('#myCustomCheckbox1').on('checked.fu.checkbox', function(evt, data) {
-		log('checked');
-	});
-	$('#myCustomCheckbox1').on('unchecked.fu.checkbox', function(evt, data) {
-		log('unchecked');
-	});
+	// $('#myCustomCheckbox1 > input').on('change', function(){
+	// 	console.log('changed');
+	// });
 
-
+	// $('#myCustomCheckbox1').trigger('click');
 	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 		COMBOBOX
 	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/js/checkbox.js
+++ b/js/checkbox.js
@@ -31,133 +31,191 @@
 	var Checkbox = function (element, options) {
 		this.options = $.extend({}, $.fn.checkbox.defaults, options);
 
-		if(element.tagName.toLowerCase() !== 'label') {
-			//console.log('initialize checkbox on the label that wraps the checkbox');
-			return;
+		// cache elements
+		this.$element = $(element).is('input[type="checkbox"]') ? $(element) : $(element).find('input[type="checkbox"]:first');
+		this.$label = this.$element.parent();
+		this.$parent = this.$label.parent('.checkbox');
+		this.$toggleContainer = this.$element.attr('data-toggle');
+		this.state = {
+			disabled: false,
+			checked: false
+		};
+
+		if (this.$parent.length === 0) {
+			this.$parent = null;
 		}
 
-		// cache elements
-		this.$label = $(element);
-		this.$chk = this.$label.find('input[type="checkbox"]');
-		this.$container = $(element).parent('.checkbox'); // the container div
+		if (Boolean(this.$toggleContainer)) {
+			this.$toggleContainer = $(this.$toggleContainer);
+		} else {
+			this.$toggleContainer = null;
+		}
 
-		// determine if a toggle container is specified
-		var containerSelector = this.$chk.attr('data-toggle');
-		this.$toggleContainer = $(containerSelector);
-
-		// handle internal events
-		this.$chk.on('change', $.proxy(this.itemchecked, this));
+		// handle events
+		this.$element.on('change.fu.checkbox', $.proxy(this.itemchecked, this));
+		this.$label.unbind('click', $.proxy(this.toggle, this));//unbind previous binds so that double clickage doesn't happen (thus making checkbox appear to not work)
+		this.$label.on('click', $.proxy(this.toggle, this));//make repeated label clicks work
 
 		// set default state
-		this.setInitialState();
+		this.setState();
 	};
 
 	Checkbox.prototype = {
 
 		constructor: Checkbox,
 
-		setInitialState: function() {
-			var $chk = this.$chk;
-			var $lbl = this.$label;
+		setState: function ($chk) {
+			$chk = $chk || this.$element;
 
-			// get current state of input
-			var checked = $chk.prop('checked');
-			var disabled = $chk.prop('disabled');
+			this.state.disabled = Boolean($chk.prop('disabled'));
+			this.state.checked = Boolean($chk.is(':checked'));
 
-			// sync label class with input state
-			this.setCheckedState($chk, checked);
-			this.setDisabledState($chk, disabled);
-		},
+			this._resetClasses();
 
-		setCheckedState: function(element, checked) {
-			var $chk = element;
-			var $lbl = this.$label;
-			var $container = this.$container;
-			var $containerToggle = this.$toggleContainer;
+			// set state of checkbox
+			this._toggleCheckedState();
+			this._toggleDisabledState();
 
-			// set class on outer container too...to support highlighting
-			// TODO: verify inline checkboxes, also test with MCTheme
-
-			if(checked) {
-				$chk.prop('checked', true);
-				$lbl.addClass('checked');
-				//$container.addClass('checked');
-				$containerToggle.removeClass('hide hidden');
-				$lbl.trigger('checked.fu.checkbox');
-			}
-			else {
-				$chk.prop('checked', false);
-				$lbl.removeClass('checked');
-				//$container.removeClass('checked');
-				$containerToggle.addClass('hidden');
-				$lbl.trigger('unchecked.fu.checkbox');
-			}
-
-			$lbl.trigger('changed.fu.checkbox', checked);
-		},
-
-		setDisabledState: function(element, disabled) {
-			var $chk = element;
-			var $lbl = this.$label;
-
-			if(disabled) {
-				this.$chk.prop('disabled', true);
-				$lbl.addClass('disabled');
-				$lbl.trigger('disabled.fu.checkbox');
-			}
-			else {
-				this.$chk.prop('disabled', false);
-				$lbl.removeClass('disabled');
-				$lbl.trigger('enabled.fu.checkbox');
-			}
-		},
-
-		itemchecked: function (evt) {
-			var $chk = $(evt.target);
-			var checked = $chk.prop('checked');
-
-			this.setCheckedState($chk, checked);
-		},
-
-		toggle: function () {
-			var checked = this.isChecked();
-
-			if(checked) {
-				this.uncheck();
-			}
-			else {
-				this.check();
-			}
-		},
-
-		check: function () {
-			this.setCheckedState(this.$chk, true);
-		},
-
-		uncheck: function () {
-			this.setCheckedState(this.$chk, false);
-		},
-
-		isChecked: function () {
-			var checked = this.$chk.prop('checked');
-			return checked;
+			//toggle container
+			this.toggleContainer();
 		},
 
 		enable: function () {
-			this.setDisabledState(this.$chk, false);
+			this.state.disabled = false;
+			this.$element.removeAttr('disabled');
+			this.$element.prop('disabled', false);
+			this._resetClasses();
+			this.$element.trigger('enabled.fu.checkbox');
 		},
 
 		disable: function () {
-			this.setDisabledState(this.$chk, true);
+			this.state.disabled = true;
+			this.$element.prop('disabled', true);
+			this.$element.attr('disabled', 'disabled');
+			this._setDisabledClass();
+			this.$element.trigger('disabled.fu.checkbox');
+		},
+
+		check: function () {
+			this.state.checked = true;
+			this.$element.prop('checked', true);
+			this.$element.attr('checked', 'checked');
+			this._setCheckedClass();
+			this.$element.trigger('checked.fu.checkbox');
+		},
+
+		uncheck: function () {
+			this.state.checked = false;
+			this.$element.prop('checked', false);
+			this.$element.removeAttr('checked');
+			this._resetClasses();
+			this.$element.trigger('unchecked.fu.checkbox');
+		},
+
+		isChecked: function () {
+			return this.state.checked;
+		},
+
+		toggle: function (e) {
+			//keep checkbox from being used if it is disabled. You can't rely on this.state.disabled, because on bind time it might not be disabled, but, state.disabled may be set to true after bind time (and this.state.disabled won't be updated for this bound instance)
+			//To see how this works, uncomment the next line of code and go to http://0.0.0.0:8000/index.html click the "disable #myCustomCheckbox1" and then click on the first checkbox and see the disparity in the output between this.state and this.$element.attr
+			//console.log('is disabled? this.state says, "' + this.state.disabled + '"; this.$element.attr says, "' + this.$element.attr('disabled') + '"');
+			if (/* do not change this to this.state.disabled. It will break edge cases */ this.$element.prop('disabled')) {
+				return;
+			}
+
+			//keep event from firing twice in Chrome
+			if (!e || (e.target === e.originalEvent.target)) {
+				this.state.checked = !this.state.checked;
+
+				this._toggleCheckedState();
+
+				if (Boolean(e)) {
+					//stop bubbling, otherwise event fires twice in Firefox.
+					e.preventDefault();
+					//make change event still fire (prevented by preventDefault to avoid firefox bug, see preceeding line)
+					this.$element.trigger('change', e);
+				}
+
+			}
+		},
+
+		toggleContainer: function () {
+			if (Boolean(this.$toggleContainer)) {
+				if (this.state.checked) {
+					this.$toggleContainer.removeClass('hide hidden');
+					this.$toggleContainer.attr('aria-hidden', 'false');
+				} else {
+					this.$toggleContainer.addClass('hidden');
+					this.$toggleContainer.attr('aria-hidden', 'true');
+				}
+
+			}
+		},
+
+		itemchecked: function (element) {
+			this.setState($(element.target));
 		},
 
 		destroy: function () {
-			this.$label.remove();
+			this.$parent.remove();
 			// remove any external bindings
 			// [none]
 			// empty elements to return to original markup
 			// [none]
-			return this.$label[0].outerHTML;
+			return this.$parent[0].outerHTML;
+		},
+
+		_resetClasses: function () {
+			var classesToRemove = [];
+
+			if (!this.state.checked) {
+				classesToRemove.push('checked');
+			}
+
+			if (!this.state.disabled) {
+				classesToRemove.push('disabled');
+			}
+
+			classesToRemove = classesToRemove.join(' ');
+
+			this.$label.removeClass(classesToRemove);
+
+			if (this.$parent) {
+				this.$parent.removeClass(classesToRemove);
+			}
+		},
+
+		_toggleCheckedState: function () {
+			if (this.state.checked) {
+				this.check();
+			} else {
+				this.uncheck();
+			}
+		},
+
+		_toggleDisabledState: function () {
+			if (this.state.disabled) {
+				this.disable();
+			} else {
+				this.enable();
+			}
+		},
+
+		_setCheckedClass: function () {
+			this.$label.addClass('checked');
+
+			if (this.$parent) {
+				this.$parent.addClass('checked');
+			}
+		},
+
+		_setDisabledClass: function () {
+			this.$label.addClass('disabled');
+
+			if (this.$parent) {
+				this.$parent.addClass('disabled');
+			}
 		}
 	};
 
@@ -197,7 +255,7 @@
 	// DATA-API
 
 	$(document).on('mouseover.fu.checkbox.data-api', '[data-initialize=checkbox]', function (e) {
-		var $control = $(e.target);
+		var $control = $(e.target).closest('.checkbox').find('[type=checkbox]');
 		if (!$control.data('fu.checkbox')) {
 			$control.checkbox($control.data());
 		}
@@ -205,7 +263,7 @@
 
 	// Must be domReady for AMD compatibility
 	$(function () {
-		$('[data-initialize=checkbox]').each(function () {
+		$('[data-initialize=checkbox] [type=checkbox]').each(function () {
 			var $this = $(this);
 			if (!$this.data('fu.checkbox')) {
 				$this.checkbox($this.data());

--- a/less/checkbox.less
+++ b/less/checkbox.less
@@ -13,7 +13,7 @@
 			//margin-left: -8px;
 		}
 
-		&.checked label.checkbox-custom, label.checked.checkbox-custom {
+		&.checked label.checkbox-custom {
 			background: #e9e9e9;
 			border-radius: @baseBorderRadius;
 		}

--- a/test/checkbox-test.js
+++ b/test/checkbox-test.js
@@ -23,276 +23,135 @@ define(function(require){
 		ok($chk1.checkbox() === $chk1, 'checkbox should be initialized');
 	});
 
-	test("should set initial state for checked/enabled", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
+	test("should set initial state", function () {
+		var $list = $(html);
 
-		// initialize checkbox
-		$element.find('label').checkbox();
+		$list.find('input').checkbox();
 
-		// ensure label has checked class
-		var checked = $element.find('label').hasClass('checked');
-		equal(checked, true, 'label has "checked" class when input is checked');
+		// checked/enabled
+		var wrapper1 = $list.find('#CheckboxWrapper1');
+		equal(wrapper1.hasClass('checked'), true, 'wrapper1 has checked class');
+		equal(wrapper1.hasClass('disabled'), false, 'wrapper1 does not have disabled class');
 
-		// ensure label does not have disabled class
-		var disabled = $element.find('label').hasClass('disabled');
-		equal(disabled, false, 'label does not have "disabled" class when input is enabled');
+		// unchecked/enabled
+		var wrapper3 = $list.find('#CheckboxWrapper3');
+		equal(wrapper3.hasClass('checked'), false, 'wrapper3 does not have checked class');
+		equal(wrapper3.hasClass('disabled'), false, 'wrapper3 does not have disabled class');
+
+		// checked/disabled
+		var wrapper4 = $list.find('#CheckboxWrapper4');
+		equal(wrapper4.hasClass('checked'), true, 'wrapper4 has checked class');
+		equal(wrapper4.hasClass('disabled'), true, 'wrapper4 has disabled class');
+
+		// checked/disabled
+		var wrapper5 = $list.find('#CheckboxWrapper5');
+		equal(wrapper5.hasClass('checked'), false, 'wrapper5 does not have checked class');
+		equal(wrapper5.hasClass('disabled'), true, 'wrapper5 has disabled class');
 	});
 
-	test("should set initial state for checked/disabled", function () {
-		var $element = $(html).find('#CheckboxCheckedDisabled').clone();
+	test("should disable/enable checkbox", function () {
+		var $chk1 = $(html).find('#Checkbox1');
 
-		// initialize checkbox
-		$element.find('label').checkbox();
-
-		// ensure label has checked class
-		var checked = $element.find('label').hasClass('checked');
-		equal(checked, true, 'label has "checked" class when input is checked');
-
-		// ensure label has disabled class
-		var disabled = $element.find('label').hasClass('disabled');
-		equal(disabled, true, 'label has "disabled" class when input is disabled');
+		equal($chk1.is(':disabled'), false, 'enabled - default state');
+		$chk1.checkbox('disable');
+		equal($chk1.is(':disabled'), true, 'disabled');
+		$chk1.checkbox('enable');
+		equal($chk1.is(':disabled'), false, 're-enabled');
 	});
 
-	test("should set initial state for unchecked/enabled", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
+	test("toggle should check/uncheck checkbox", function () {
+		var $fixture = $(html).appendTo('#qunit-fixture');
+		var $chk1 = $fixture.find('#Checkbox1');
 
-		// initialize checkbox
-		$element.find('label').checkbox();
+		equal($chk1.is(':checked'), true, 'starts checked - confirmation by is(:checked)');
+		$chk1.checkbox('toggle');
+		equal($chk1.is(':checked'), false, 'calling toggle unchecks - confirmation by is(:checked)');
+		$chk1.checkbox('toggle');
+		equal($chk1.is(':checked'), true, 'calling toggle again ends with checked - confirmation by is(:checked)');
 
-		// ensure label does not have checked class
-		var checked = $element.find('label').hasClass('checked');
-		equal(checked, false, 'label does not have "checked" class when input is unchecked');
-
-		// ensure label does not have disabled class
-		var disabled = $element.find('label').hasClass('disabled');
-		equal(disabled, false, 'label does not have "disabled" class when input is enabled');
+		$fixture.remove();
 	});
 
-	test("should set initial state for unchecked/disabled", function () {
-		var $element = $(html).find('#CheckboxUncheckedDisabled').clone();
+	test("click should check/uncheck checkbox", function () {
+		var $fixture = $(html).appendTo('#qunit-fixture');
+		var $chk1 = $fixture.find('#Checkbox1');
 
-		// initialize checkbox
-		$element.find('label').checkbox();
+		equal($chk1.is(':checked'), true, 'starts checked - confirmation by is(:checked)');
+		$chk1.trigger('click');
+		equal($chk1.is(':checked'), false, 'calling click unchecks - confirmation by is(:checked)');
+		$chk1.trigger('click');
+		equal($chk1.is(':checked'), true, 'calling click again checks - confirmation by is(:checked)');
 
-		// ensure label does not have checked class
-		var checked = $element.find('label').hasClass('checked');
-		equal(checked, false, 'label does not have "checked" class when input is unchecked');
-
-		// ensure label has disabled class
-		var disabled = $element.find('label').hasClass('disabled');
-		equal(disabled, true, 'label has "disabled" class when input is disabled');
+		$fixture.remove();
 	});
 
-	test("should disable checkbox", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
+	test("test check/uncheck/isChecked convenience methods", function () {
+		var $fixture = $(html).appendTo('#qunit-fixture');
+		var $chk5 = $fixture.find('#Checkbox5');
+		var $wrapper5 = $fixture.find('#CheckboxWrapper5');
 
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
+		$chk5.checkbox();
 
-		// set disabled state
-		equal($input.prop('disabled'), false, 'checkbox enabled initially');
-		$chk.checkbox('disable');
-		equal($input.prop('disabled'), true, 'checkbox disabled after calling disable method');
+		equal($chk5.is(':checked'), false, 'unchecked - default value');
+
+		$chk5.checkbox('check');
+		equal($chk5.is(':checked'), true, 'checked - confirmation by is(:checked)');
+		equal($wrapper5.hasClass('checked'), true, 'checked - confirmation by css class');
+		equal($chk5.checkbox('isChecked'), true, 'checked - confirmation by isChecked method');
+
+		$chk5.checkbox('uncheck');
+		equal($chk5.is(':checked'), false, 'unchecked - confirmation by is(:checked)');
+		equal($wrapper5.hasClass('checked'), false, 'unchecked - confirmation by css class');
+		equal($chk5.checkbox('isChecked'), false, 'unchecked - confirmation by isChecked method');
+
+		$fixture.remove();
 	});
 
-	test("should enable checkbox", function () {
-		var $element = $(html).find('#CheckboxUncheckedDisabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
+	test("onchange should occur", function() {
+		var $fixture = $(html).appendTo('#qunit-fixture');
+		var $chk1Wrapper = $fixture.find('#CheckboxWrapperChangeCheck');
+		var $chk1 = $chk1Wrapper.find('input');
 
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
+		var changeOccurred = false;
 
-		// set enabled state
-		equal($input.prop('disabled'), true, 'checkbox disabled initially');
-		$chk.checkbox('enable');
-		equal($input.prop('disabled'), false, 'checkbox enabled after calling enable method');
-	});
+		equal(changeOccurred, false, 'No change occurred yet');
 
-	test("should check checkbox", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		// set checked state
-		equal($input.prop('checked'), false, 'checkbox unchecked initially');
-		$chk.checkbox('check');
-		equal($input.prop('checked'), true, 'checkbox checked after calling check method');
-	});
-
-	test("should uncheck checkbox", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		// set checked state
-		equal($input.prop('checked'), true, 'checkbox checked initially');
-		$chk.checkbox('uncheck');
-		equal($input.prop('checked'), false, 'checkbox unchecked after calling uncheck method');
-	});
-
-	test("should toggle checkbox", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		// set checked state
-		equal($input.prop('checked'), true, 'checkbox checked initially');
-		$chk.checkbox('toggle');
-		equal($input.prop('checked'), false, 'checkbox unchecked after calling toggle method');
-		$chk.checkbox('toggle');
-		equal($input.prop('checked'), true, 'checkbox checked after calling toggle method');
-		$chk.checkbox('toggle');
-		equal($input.prop('checked'), false, 'checkbox unchecked after calling toggle method');
-	});
-
-	test("should return checked state", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		// verify checked state changes with toggle method
-		equal($chk.checkbox('isChecked'), true, 'checkbox state is checked');
-		$chk.checkbox('toggle');
-		equal($chk.checkbox('isChecked'), false, 'checkbox state is unchecked');
-		$chk.checkbox('toggle');
-		equal($chk.checkbox('isChecked'), true, 'checkbox state is checked');
-
-		// verify checked state changes with uncheck method
-		$chk.checkbox('uncheck');
-		equal($chk.checkbox('isChecked'), false, 'checkbox state is unchecked');
-
-		// verify checked state changes with check method
-		$chk.checkbox('check');
-		equal($chk.checkbox('isChecked'), true, 'checkbox state is checked');
-	});
-
-	test("should trigger checked event when calling check method", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		var triggered = false;
-		$chk.on('checked.fu.checkbox', function(){
-			triggered = true;
+		//this doesn't work right from terminal, but, if you open in browser you'll see 'changed' in console
+		$chk1.on('change', function(){
+			if(window.console && window.console.log) {
+				console.log('change fired');
+			}
+			changeOccurred = true;
 		});
 
-		$chk.checkbox('check');
+		//clicking label should check box and trigger click
+		$chk1Wrapper.find('label').trigger('click');
 
-		equal(triggered, true, 'checked event triggered');
+		//this kind of breaks the whole purpose of this test, but, otherwise the test doesn't work via terminal
+		if($chk1.is(':checked')){
+			changeOccurred = true;
+		}
+
+		stop(); // Pause the test
+		//Add your wait
+		setTimeout(function() {
+			//Make assertion
+			equal(changeOccurred, true, 'onchange triggered');
+			// After the assertion called, restart the test
+			start();
+		}, 1000);
+
+
+		$fixture.remove();
 	});
 
-	test("should trigger unchecked event when calling uncheck method", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
+	test("should destroy control", function () {
+		var id = '#Checkbox1';
+		var $el = $(html).find(id);
+		var $parent = $el.closest('.checkbox');
 
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		var triggered = false;
-		$chk.on('unchecked.fu.checkbox', function(){
-			triggered = true;
-		});
-
-		$chk.checkbox('uncheck');
-
-		equal(triggered, true, 'unchecked event triggered');
+		equal($el.checkbox('destroy'), '' + $parent[0].outerHTML, 'returns markup');
+		equal( $(html).find(id).length, false, 'element has been removed from DOM');
 	});
 
-	test("should trigger changed event when calling checked/unchecked method", function () {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		var triggered = false;
-		var state = false;
-		$chk.on('changed.fu.checkbox', function(evt, data){
-			triggered = true;
-			state = data;
-		});
-
-		$chk.checkbox('uncheck');
-
-		equal(triggered, true, 'changed event triggered');
-		equal(state, false, 'changed event triggered passing correct state');
-	});
-
-	test("should trigger changed event when clicking on input element", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-		$element.appendTo(document.body); // append to body to capture clicks
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		var triggered = false;
-		$element.on('changed.fu.checkbox', function(){
-			triggered = true;
-		});
-
-		$input.click();
-		equal(triggered, true, 'changed event triggered');
-
-		$element.remove();
-	});
-
-	test("should trigger changed event when clicking on input element", function () {
-		var $element = $(html).find('#CheckboxUncheckedEnabled').clone();
-		var $input = $element.find('input[type="checkbox"]');
-		$element.appendTo(document.body); // append to body to capture clicks
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		var triggered = false;
-		$element.on('changed.fu.checkbox', function(){
-			triggered = true;
-		});
-
-		$input.click();
-		equal(triggered, true, 'changed event triggered');
-
-		$element.remove();
-	});
-
-	test("should toggle checkbox container visibility", function() {
-		var $element = $(html).find('#CheckboxToggle').clone();
-		var $container = $element.find('.checkboxToggle');
-		$element.appendTo(document.body); // append to body to check visibility
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-
-		equal($container.is(':visible'), false, 'toggle container hidden by default');
-		$chk.checkbox('check');
-		equal($container.is(':visible'), true, 'toggle container visible after check');
-		$chk.checkbox('uncheck');
-		equal($container.is(':visible'), false, 'toggle container hidden after uncheck');
-
-		$element.remove();
-	});
-
-	test("should destroy checkbox", function() {
-		var $element = $(html).find('#CheckboxCheckedEnabled').clone();
-
-		// initialize checkbox
-		var $chk = $element.find('label').checkbox();
-		var originalMarkup = $element.find('label')[0].outerHTML;
-
-		equal($element.find('#Checkbox1').length, 1, 'checkbox exists in DOM by default');
-
-		var markup = $chk.checkbox('destroy');
-
-		equal(originalMarkup, markup, 'returned original markup');
-		equal($element.find('#Checkbox1').length, 0, 'checkbox removed from DOM');
-	});
 });

--- a/test/markup/checkbox-markup.html
+++ b/test/markup/checkbox-markup.html
@@ -1,42 +1,41 @@
 <div id="MyCheckboxContainer">
 
-	<div id="CheckboxCheckedEnabled" class="checkbox">
+	<div id="CheckboxWrapper1" class="checkbox">
 		<label class="checkbox-custom">
-			<input class="sr-only checked" type="checkbox" checked="checked" id="Checkbox1">
-			<span class="checkbox-label">Checked/Enabled</span>
+			<input id="Checkbox1" class="sr-only checked" type="checkbox" value="" checked="checked">
+			<span class="checkbox-label">Custom appearance checkbox checked at page load (#chk1)</span>
+		</label>
+	</div>
+	<div id="CheckboxWrapper2" class="checkbox">
+		<label class="checkbox-custom">
+			<input id="Checkbox2" class="sr-only checked" type="checkbox" value="" checked="checked" data-toggle="#checkboxToggle1">
+			<span class="checkbox-label">Custom appearance checkbox checked at page load with linked element visibility toggle by id </span>
+		</label>
+	</div>
+	<div id="CheckboxWrapper3" class="checkbox">
+		<label class="checkbox-custom">
+			<input id="Checkbox3" class="sr-only checkbox" type="checkbox" value="" data-toggle=".checkboxToggle2">
+			<span class="checkbox-label">Custom appearance checkbox unchecked on page load <i>with linked element visibility toggle by class</i></span>
+		</label>
+	</div>
+	<div id="CheckboxWrapper4" class="checkbox">
+		<label class="checkbox-custom">
+			<input id="Checkbox4" class="sr-only checkbox" type="checkbox" value="" checked="checked" disabled="disabled">
+			<span class="checkbox-label">Disabled custom appearance checkbox <i>checked on page load</i></span>
+		</label>
+	</div>
+	<div id="CheckboxWrapper5" class="checkbox">
+		<label class="checkbox-custom">
+			<input id="Checkbox5" class="sr-only checkbox" type="checkbox" value="" disabled="disabled">
+			<span class="checkbox-label">Disabled custom appearance checkbox <i>unchecked on page load</i></span>
 		</label>
 	</div>
 
-	<div id="CheckboxCheckedDisabled" class="checkbox">
+	<div id="CheckboxWrapperChangeCheck" class="checkbox">
 		<label class="checkbox-custom">
-			<input class="sr-only checked" type="checkbox" checked="checked" disabled="disabled">
-			<span class="checkbox-label">Checked/Disabled</span>
+			<input id="CheckboxChangeCheck" class="sr-only checked" type="checkbox" value="" checked="checked">
+			<span class="checkbox-label">Custom appearance checkbox checked at page load (#CheckboxChangeCheck)</span>
 		</label>
-	</div>
-
-	<div id="CheckboxUncheckedEnabled" class="checkbox">
-		<label class="checkbox-custom">
-			<input class="sr-only checked" type="checkbox">
-			<span class="checkbox-label">Unchecked/Enabled</span>
-		</label>
-	</div>
-
-	<div id="CheckboxUncheckedDisabled" class="checkbox">
-		<label class="checkbox-custom">
-			<input class="sr-only checked" type="checkbox" disabled="disabled">
-			<span class="checkbox-label">Unchecked/Disabled</span>
-		</label>
-	</div>
-
-
-	<div id="CheckboxToggle">
-		<div class="checkbox">
-			<label class="checkbox-custom">
-				<input type="checkbox" class="sr-only" data-toggle=".checkboxToggle">
-				Custom checkbox toggles by class
-			</label>
-		</div>
-		<div class="checkboxToggle hidden">This message's visibility toggles by class with a checkbox above.</div>
 	</div>
 
 </div>


### PR DESCRIPTION
Due to an internal timeline, the team has decided to revert the breaking change in markup for checkbox, so that we can release 3.7.2 today instead of 3.8.0.

For more background information on the markup changes that were committed into master and now reverted, please review the [3.7.0 release notes](https://github.com/ExactTarget/fuelux/releases/tag/3.7.0).