### PR TITLE
Tree select bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2358,7 +2358,8 @@
 
 			</div>
 			<div class="btn-panel">
-				<button type="button" class="btn btn-default" id="btnTreeDestroy">destroy and append</button>
+        <button type="button" class="btn btn-default" id="btnTreeDestroy">destroy and append</button>
+				<button type="button" class="btn btn-default" id="btnTreeClearSelected">clear all selected</button>
 				<button type="button" class="btn btn-default" id="btnTreeDiscloseVisible">disclose visible</button>
 				<button type="button" class="btn btn-default" id="btnTreeDiscloseAll">disclose all</button>
 				<button type="button" class="btn btn-default" id="btnTreeCloseAll">close all</button>

--- a/index.js
+++ b/index.js
@@ -992,6 +992,10 @@ myTreeInit();
 		myTreeInit();
 	});
 
+	$('#btnTreeClearSelected').click(function () {
+		log('Items/folders cleared: ', $('#myTree1').tree('clearSelected') );
+	});
+
 	$('#btnTreeDiscloseVisible').click(function () {
 		$('#myTree1').tree('discloseVisible');
 	});

--- a/index.js
+++ b/index.js
@@ -993,7 +993,7 @@ myTreeInit();
 	});
 
 	$('#btnTreeClearSelected').click(function () {
-		log('Items/folders cleared: ', $('#myTree1').tree('clearSelected') );
+		log('Items/folders cleared: ', $('#myTree1').tree('deselectAll') );
 	});
 
 	$('#btnTreeDiscloseVisible').click(function () {

--- a/test/markup/tree-markup.html
+++ b/test/markup/tree-markup.html
@@ -66,6 +66,13 @@
 				<ul class="tree-branch-children"></ul>
 				<div class="tree-loader" role="alert">Loading...</div>
 			</li>
+			<!-- item template -->
+			<li class="tree-item hidden" data-template="treeitem" role="treeitem">
+				<button class="tree-item-name">
+					<span class="glyphicon icon-item fueluxicon-bullet"></span>
+					<span class="tree-label">Example Item</span>
+				</button>
+			</li>
 		</ul>
 
 	</div>

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -182,12 +182,13 @@ define(function (require) {
 
 		$selNode = $tree.find('.tree-branch:eq(1)');
 		$tree.tree('discloseFolder', $selNode.find('.tree-branch-header'));
-		equal($selNode.find('.tree-branch-children > li').length, 4, 'Folder has been populated with sub-folders');
+		equal($selNode.find('.tree-branch-children > li').length, 8, 'Folder has been populated with sub-folders and items');
 	});
 
 	test("Single item/folder selection works as designed", function () {
 		var $tree = $(html).find('#MyTree');
 
+		// multiSelect: false is the default
 		$tree.tree({
 			dataSource: this.dataSource
 		});
@@ -204,10 +205,24 @@ define(function (require) {
 			folderSelect: true
 		});
 
-		$tree.tree('selectItem', $tree.find('.tree-branch-name:eq(1)'));
-		equal($tree.tree('selectedItems').length, 1, 'Return single selected value');
-		$tree.tree('selectItem', $tree.find('.tree-branch-name:eq(2)'));
-		equal($tree.tree('selectedItems').length, 1, 'Return new single selected value');
+		$tree.tree('selectItem', $tree.find('.tree-item:eq(1)'));
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected item (none previously selected, 1st programatic selection)');
+
+		$tree.tree('selectFolder', $tree.find('.tree-branch-name:eq(1)'));
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected folder (item previously selected, 2nd programatic selection)');
+
+		$tree.tree('selectItem', $tree.find('.tree-item:eq(2)'));
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected item (folder previously selected, 3rd programatic selection)');
+
+		$tree.find('.tree-item:eq(1)').click();
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected item (item previously selected, 1st click selection)');
+
+		$tree.find('.tree-branch-name:eq(1)').click();
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected folder (item previously selected, 2nd click selection)');
+
+		$tree.find('.tree-item:eq(2)').click();
+		equal($tree.tree('selectedItems').length, 1, 'Return single selected item (folder previously selected, 3rd click selection)');
+
 	});
 
 	test("Multiple item/folder selection works as designed", function () {


### PR DESCRIPTION
Definitely fixes #1137. May fix #1259.

- Refactor (combine majority of code) selectFolder and selectItem to re-use code.
- Add `clearSelected` method

There were several problems with this single select unit test:
- Mouse clicks were not being tested, only API methods
- Folder selectable tree needs to test items also.
- Folder selectable tree needs to test items with folders previously selected, and folders with items previously selected
- Markup for folder selectable tree did not include a `tree-item` template and therefore created only folders and did not create any items (hence 4 folders/items are returned instead of the folders/correct 8 items).
- The selectItem method was being used to select folders.

Does this fix your issue, @MJ-Vakili ? 