### PR TITLE
Make Marketing Cloud Theme documentation page future compatible

### DIFF
--- a/_includes/mctheme.html
+++ b/_includes/mctheme.html
@@ -13,33 +13,33 @@
 
 		<p>To use this theme, include the theme file <b><i>after</i></b> the complete Bootstrap CSS and the complete Fuel UX CSS. For more on setting up a page, please review <a href="getting-started.html">Getting Started</a> and modify the <a href="getting-started.html#template">quick-start templates</a> with the following:</p>
 {% highlight html %}
-<link href="{{site.bootstrap.css}}" rel="stylesheet">
-<link href="{{site.cdn.css}}" rel="stylesheet">
-<link href="{{site.mctheme.css}}" rel="stylesheet">
+<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+<link href="//www.fuelcdn.com/fuelux/3.x.x/css/fuelux.min.css" rel="stylesheet">
+<link href="//www.fuelcdn.com/fuelux-mctheme/1.x.x/css/fuelux-mctheme.min.css" rel="stylesheet">
 {% endhighlight %}
-		<p>For additional ways to use the Marketing Cloud Theme&mdash;including with Bower, please <a href="http://github.com/ExactTarget/fuelux-mctheme/">review the README file</a> within its respecitve repository</p>
+		<p>The following markup examples are based on a build of the unreleased <em>master</em> branch. Please refer to the repository for the <a href="https://github.com/ExactTarget/fuelux-mctheme/releases">latest release</a>. For additional ways to use the Marketing Cloud Theme&mdash;including with Bower, please <a href="http://github.com/ExactTarget/fuelux-mctheme/">review the README file</a> within its respecitve repository. </p>
 
 		<h3>Themed Bootstrap Elements</h3>
 		<p class="example-lead">Global CSS settings, fundamental HTML elements styled and enhanced with extensible classes.</p>
-		<iframe class="frame" src="http://exacttarget.github.io/fuelux-mctheme/examples/bootstrap-css/bootstrap-css.html" frameborder="0"></iframe>
+		<iframe class="frame" src="http://fuelux-mctheme.herokuapp.com/examples/bootstrap-css/bootstrap-css.html" frameborder="0"></iframe>
 
 		<hr class="half-rule">
 
 		<h3>Themed Bootstrap Components</h3>
 		<p class="example-lead">Over a dozen reusable components built to provide dropdowns, input groups, navigation, alerts, and much more.</p>
-		<iframe class="frame" src="http://exacttarget.github.io/fuelux-mctheme/examples/bootstrap-components/bootstrap-components.html" frameborder="0"></iframe>
+		<iframe class="frame" src="http://fuelux-mctheme.herokuapp.com/examples/bootstrap-components/bootstrap-components.html" frameborder="0"></iframe>
 
 		<hr class="half-rule">
 
 		<h3>Themed Bootstrap Controls</h3>
 		<p class="example-lead">Bring Bootstrap's components to life with over a dozen custom jQuery plugins.</p>
-		<iframe class="frame" src="http://exacttarget.github.io/fuelux-mctheme/examples/bootstrap-javascript/bootstrap-javascript.html" frameborder="0"></iframe>
+		<iframe class="frame" src="http://fuelux-mctheme.herokuapp.com/examples/bootstrap-javascript/bootstrap-javascript.html" frameborder="0"></iframe>
 
 		<hr class="half-rule">
 
 		<h3>Themed Fuel UX Controls</h3>
 		<p class="example-lead">More than one dozen reusable controls built to provide data repeaters, datepickers, pillboxes, trees, wizards, and much more. <a href="javascript.html">Learn more about Fuel UX controls</a></p>
-		<iframe class="frame" src="http://exacttarget.github.io/fuelux-mctheme/examples/fuelux/fuelux.html" frameborder="0"></iframe>
+		<iframe class="frame" src="http://fuelux-mctheme.herokuapp.com/examples/fuelux/fuelux.html" frameborder="0"></iframe>
 
 		<hr class="half-rule">
 


### PR DESCRIPTION
Just got an email this morning from a developer asking why the markup was different between:
- http://getfuelux.com/mctheme/index.html#mctheme
- http://exacttarget.github.io/fuelux-mctheme/
- http://fuelux-mctheme.herokuapp.com/

Task completed:
- Replace fixed version asset links with ambiguous x-range
- Update iframes to edge server (the Herkou app) which has latest markup