### PR TITLE
Allow radio button by default to be checked if it is not last

### DIFF
--- a/js/radio.js
+++ b/js/radio.js
@@ -84,15 +84,15 @@
 		},
 
 		setCheckedState: function(element, checked) {
-			// reset all items in group
-			this.resetGroup();
-
 			var $radio = element;
 			var $lbl = $radio.parent();
 			var containerSelector = $radio.attr('data-toggle');
 			var $containerToggle = $(containerSelector);
 
 			if(checked) {
+				// reset all items in group
+				this.resetGroup();
+
 				$radio.prop('checked', true);
 				$lbl.addClass('checked');
 				$containerToggle.removeClass('hide hidden');


### PR DESCRIPTION
Fixes #1306 by correcting bug in radio control where `resetGroup` was called every time `setCheckedState` was called, regardless if whether the current radio was being checked or unchecked