### PR TITLE
bug-fix/npm scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   },
   "scripts": {
     "main": "devserver.js",
-    "postinstall": "./node_modules/bower/bin/bower install && tar -zcf dev/node_modules.tar.gz node_modules/;",
-    "test": "grunt travisci --verbose"
+    "postinstall": "node ./node_modules/bower/bin/bower install",
+    "test": "tar -zcf dev/node_modules.tar.gz node_modules/ && grunt travisci --verbose"
   },
   "title": "Fuel UX",
   "version": "3.7.3",


### PR DESCRIPTION
The postInstall cmd did not work on windows, this fixes that.

The tar command didn't work as well b/c some modules have file paths too long for windows to comprehend. Since the tar is ignored form the repo and only used in the travis build, I moved that command to be a step before npm test (only run on travis I assume).

If this is not the correct way, please let me know as this problem has more of a barrier to entry for devs on windows