### PR TITLE
Make install process Windows compatible

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: grunt dist && node devserver.js
+web: tar -zcf dev/node_modules.tar.gz node_modules/ && grunt dist && node devserver.js

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "main": "devserver.js",
-    "postinstall": "./node_modules/bower/bin/bower install && tar -zcf dev/node_modules.tar.gz node_modules/;",
+    "postinstall": "node ./node_modules/bower/bin/bower install",
     "test": "grunt travisci --verbose"
   },
   "title": "Fuel UX",


### PR DESCRIPTION
Move node_module archiving to Procfile `tar` command, so it only run on Heroku, and fixes #1331 for those that run on Windows or don't have `tar` installed. It also adds `node` before the bower command which makes it Windows compatible.