### PR TITLE
Trigger `changed` event when scheduler's datepicker `dateClicked` is triggered

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,8 +141,13 @@ define(function (require) {
 
 	// events
 	$('#myDatepicker').on('changed.fu.datepicker', function (event, data) {
-		log('datepicker change event fired');
+		log('datepicker change event fired: ' + data);
 	});
+
+	$('#myDatepicker').on('dateClicked.fu.datepicker', function (event, data) {
+		log('datepicker dateClicked event fired: ' + data);
+	});
+
 	$('#myDatepicker').on('inputParsingFailed.fu.datepicker', function () {
 		log('datepicker inputParsingFailed event fired');
 	});

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -97,6 +97,7 @@
 		});
 		this.$element.find('.combobox').on('changed.fu.combobox', $.proxy(this.changed, this));
 		this.$element.find('.datepicker').on('changed.fu.datepicker', $.proxy(this.changed, this));
+		this.$element.find('.datepicker').on('dateClicked.fu.datepicker', $.proxy(this.changed, this));
 		this.$element.find('.selectlist').on('changed.fu.selectlist', $.proxy(this.changed, this));
 		this.$element.find('.spinbox').on('changed.fu.spinbox', $.proxy(this.changed, this));
 		this.$element.find('.repeat-monthly .radio-custom, .repeat-yearly .radio-custom').on('change.fu.scheduler', $.proxy(this.changed, this));


### PR DESCRIPTION
Fixes #1344.

Also adds datepicker `dateClicked` console logging to `index.js` in order to document more events and was helpful in diagnosing why `changed.fu.scheduler` was not being triggered.