### PR TITLE
Wrap wizard steps in hidden overflow instead of entire control

### DIFF
--- a/index.html
+++ b/index.html
@@ -2373,18 +2373,20 @@
 				<h2>Wizard</h2>
 				<div class="thin-box">
 					<div class="wizard" data-initialize="wizard" id="myWizard">
-						<ul class="steps">
-							<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
-							</li>
-							<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
-							</li>
-							<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
-							</li>
-							<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
-							</li>
-							<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
-							</li>
-						</ul>
+						<div class="steps-container">
+							<ul class="steps">
+								<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span>
+								</li>
+								<li class="active" data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span>
+								</li>
+								<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span>
+								</li>
+								<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span>
+								</li>
+								<li data-step="5" data-name="distep"><span class="badge">5</span>Send<span class="chevron"></span>
+								</li>
+							</ul>
+						</div>
 						<div class="actions">
 							<button type="button" class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 							<button type="button" class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span>

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -39,6 +39,14 @@
 		this.$prevBtn = this.$element.find('button.btn-prev');
 		this.$nextBtn = this.$element.find('button.btn-next');
 
+		// maintains backwards compatibility with < 3.8, will be removed in the future
+		if (this.$element.children('.steps-container').length === 0) {
+			this.$element.addClass('no-steps-container');
+			if (window && window.console && window.console.warn) {
+				window.console.warn('please update your wizard markup to include ".steps-container" as seen in http://getfuelux.com/javascript.html#wizard-usage-markup');
+			}
+		}
+
 		kids = this.$nextBtn.children().detach();
 		this.nextText = $.trim(this.$nextBtn.text());
 		this.$nextBtn.append(kids);

--- a/less/wizard.less
+++ b/less/wizard.less
@@ -10,13 +10,22 @@
 		background-color: @tableBackgroundAccent;
 		position: relative;
 		min-height: 48px;
-		overflow: hidden;
 
-		> .steps {
+		&.no-steps-container {	// maintains backwards compatibility with < 3.8, will be removed in the future
+			overflow: hidden;
+		}
+
+		.steps-container {
+			border-radius: @baseBorderRadius @baseBorderRadius 0 0;
+			overflow: hidden;
+
+		}
+
+		> ul.steps, > .steps-container > ul.steps {
 			list-style: none outside none;
 			padding: 0;
 			margin: 0;
-			width: 4000px;
+			width: 999999px; //using a ridiculously giant width here to allow practically infinite space for the li's to flow horizontally
 
 			&.previous-disabled {
 				li {
@@ -120,7 +129,7 @@
 		&.rtl {
 			direction: rtl;
 
-			>.steps {
+			> ul.steps, > .steps-container > ul.steps {
 				right: 0;
 				left: auto;
 				float: right;
@@ -190,6 +199,9 @@
 				right: auto;
 				left: 0;
 				float: left;
+				border-left: none;
+				border-right: 1px solid @navbarBorder;
+				border-radius: @baseBorderRadius 0 0 0;
 
 				.btn-prev {
 					span {
@@ -211,6 +223,7 @@
 			z-index: 1000;
 			position: absolute;
 			right: 0;
+			top: 0;
 			line-height: 46px;
 			float: right;
 			padding-left: 15px;
@@ -218,6 +231,7 @@
 			vertical-align: middle;
 			background-color: #e5e5e5;
 			border-left: 1px solid @navbarBorder;
+			border-radius: 0 @baseBorderRadius 0 0;
 
 			a {
 				line-height: 45px;

--- a/markup/wizard.html
+++ b/markup/wizard.html
@@ -1,6 +1,6 @@
 <div class="wizard" data-initialize="wizard" id="myWizard">
-	<div class="steps">
-		<ul>
+	<div class="steps-container">
+		<ul class="steps">
 			<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span></li>
 			<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
 			<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>

--- a/markup/wizard.html
+++ b/markup/wizard.html
@@ -1,11 +1,13 @@
 <div class="wizard" data-initialize="wizard" id="myWizard">
-	<ul class="steps">
-		<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span></li>
-		<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
-		<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
-		<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
-		<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
-	</ul>
+	<div class="steps">
+		<ul>
+			<li data-step="1"><span class="badge">1</span>Campaign<span class="chevron"></span></li>
+			<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
+			<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
+			<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
+			<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
+		</ul>
+	</div>
 	<div class="actions">
 		<button type="button" class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 		<button type="button" class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span></button>

--- a/test/markup/wizard-markup.html
+++ b/test/markup/wizard-markup.html
@@ -1,13 +1,15 @@
 <div>
 
 	<div id="MyWizard" class="wizard">
-		<ul class="steps">
-			<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
-			<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
-			<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
-			<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
-			<li data-step="5" data-name="named step"><span class="badge">5</span>Send<span class="chevron"></span></li>
-		</ul>
+		<div class="steps-container">
+			<ul class="steps">
+				<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
+				<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
+				<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
+				<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
+				<li data-step="5" data-name="named step"><span class="badge">5</span>Send<span class="chevron"></span></li>
+			</ul>
+		</div>
 		<div class="actions">
 			<button type="button" class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 			<button type="button" class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span></button>
@@ -47,13 +49,15 @@
 	</div>
 
 	<div id="MyWizardPreviousStepDisabled" class="wizard" data-restrict="previous">
-		<ul class="steps">
-			<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
-			<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
-			<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
-			<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
-			<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
-		</ul>
+		<div class="steps-container">
+			<ul class="steps">
+				<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
+				<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
+				<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
+				<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
+				<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
+			</ul>
+		</div>
 		<div class="actions">
 			<button type="button" class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 			<button type="button" class="btn btn-default btn-next" data-last="Complete">Next<span class="glyphicon glyphicon-arrow-right"></span></button>
@@ -93,13 +97,15 @@
 	</div>
 
 	<div id="MyWizardWithSpaces" class="wizard">
-		<ul class="steps">
-			<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
-			<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
-			<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
-			<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
-			<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
-		</ul>
+		<div class="steps-container">
+			<ul class="steps">
+				<li class="active" data-step="1"><span class="badge badge-info">1</span>Campaign<span class="chevron"></span></li>
+				<li data-step="2"><span class="badge">2</span>Recipients<span class="chevron"></span></li>
+				<li data-step="3"><span class="badge">3</span>Template<span class="chevron"></span></li>
+				<li data-step="4"><span class="badge">4</span>Preview<span class="chevron"></span></li>
+				<li data-step="5"><span class="badge">5</span>Send<span class="chevron"></span></li>
+			</ul>
+		</div>
 		<div class="actions">
 			<button type="button" class="btn btn-default btn-prev"><span class="glyphicon glyphicon-arrow-left"></span>Prev</button>
 			<button type="button" class="btn btn-default btn-next" data-last="Finish">Next<span class="glyphicon glyphicon-arrow-right"></span></button>

--- a/test/wizard-test.js
+++ b/test/wizard-test.js
@@ -282,10 +282,10 @@ define(function (require) {
 			label: 'Test1',
 			pane: 'Test Pane Content 1'
 		}, {
-				badge: 'T2',
-				label: 'Test2',
-				pane: 'Test Pane Content 2'
-			});
+			badge: 'T2',
+			label: 'Test2',
+			pane: 'Test Pane Content 2'
+		});
 		$test = $wizard.find('.steps li:nth-child(2)');
 		equal($test.find('.badge').text(), 'T1', 'item correctly added at index via arguments, has correct badge');
 		$test = $test.next();


### PR DESCRIPTION
Fixes #1241 by adding additional wrapper element with class `.steps-container` around the `ul.steps`, so that `overflow: hidden` is only applied to that area instead of the entire `wizard`.

This is a breaking markup change that maintains backwards compatibility by adding the class `.no-steps-container` to `.wizard` via JavaScript. Please add the `div.steps-container` element around `ul.steps` as [this markup documentation](http://getfuelux.com/javascript.html#wizard-usage-markup) when you can.

for easier comparison 
https://github.com/ExactTarget/fuelux/pull/1352/files?w=1