### PR TITLE
If selectlist is empty, disable it

### DIFF
--- a/js/selectlist.js
+++ b/js/selectlist.js
@@ -31,6 +31,7 @@
 		this.$element = $(element);
 		this.options = $.extend({}, $.fn.selectlist.defaults, options);
 
+
 		this.$button = this.$element.find('.btn.dropdown-toggle');
 		this.$hiddenField = this.$element.find('.hidden-field');
 		this.$label = this.$element.find('.selected-label');
@@ -42,6 +43,14 @@
 		if (options.resize === 'auto' || this.$element.attr('data-resize') === 'auto') {
 			this.resize();
 		}
+
+		// if selectlist is empty or is one item, disable it
+		var items = this.$dropdownMenu.children('li');
+		if( items.length === 0) {
+			this.disable();
+			this.doSelect( $(this.options.emptyLabelHTML));
+		}
+
 	};
 
 	Selectlist.prototype = {
@@ -215,7 +224,9 @@
 		return (methodReturn === undefined) ? $set : methodReturn;
 	};
 
-	$.fn.selectlist.defaults = {};
+	$.fn.selectlist.defaults = {
+		emptyLabelHTML: '<li data-value=""><a href="#">No items</a></li>'
+	};
 
 	$.fn.selectlist.Constructor = Selectlist;
 

--- a/test/markup/selectlist-markup.html
+++ b/test/markup/selectlist-markup.html
@@ -14,6 +14,29 @@
 	<input class="hidden hidden-field" name="MySelectlist" readonly="readonly" aria-hidden="true" type="text"/>
 </div>
 
+<div id="selectlistEmpty" class="btn-group selectlist" data-resize="auto">
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+		<span class="selected-label">&nbsp;</span>
+		<span class="caret"></span>
+		<span class="sr-only">Toggle Dropdown</span>
+	</button>
+	<ul class="dropdown-menu" role="menu">
+	</ul>
+	<input class="hidden hidden-field" name="MySelectlist" readonly="readonly" aria-hidden="true" type="text"/>
+</div>
+
+<div id="selectlistSingleItem" class="btn-group selectlist" data-resize="auto">
+	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+		<span class="selected-label">&nbsp;</span>
+		<span class="caret"></span>
+		<span class="sr-only">Toggle Dropdown</span>
+	</button>
+	<ul class="dropdown-menu" role="menu">
+		<li data-value="1"><a href="#">One</a></li>
+	</ul>
+	<input class="hidden hidden-field" name="MySelectlist" readonly="readonly" aria-hidden="true" type="text"/>
+</div>
+
 <div id="MySelectlist2" class="btn-group selectlist" data-resize="auto">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
 		<span class="selected-label">&nbsp;</span>

--- a/test/selectlist-test.js
+++ b/test/selectlist-test.js
@@ -58,6 +58,16 @@ define(function(require){
 		ok(($selectlist9.width() >= minWidth), 'selectlist was hidden, now shown, sized ' + $selectlist9.width() + ' should be greater than ' + minWidth);
 	});
 
+	test("should disable itself if empty", function () {
+		var $selectlist = $(html).find('#selectlistEmpty').selectlist({
+			emptyLabelHTML: '<li data-value=""><a href="#">I am feeling so empty</a></li>'
+		});
+		equal($selectlist.find('.btn').hasClass('disabled'), true, 'element disabled');
+		equal($selectlist.find('.selected-label').html(), 'I am feeling so empty', 'custom emptyLabelHTML set as label');
+		equal($selectlist.selectlist('selectedItem').text, 'I am feeling so empty', 'selectedItem returns correct text');
+		equal($selectlist.selectlist('selectedItem').value, '', 'selectedItem returns correct value');
+	});
+
 	test("should set disabled state", function () {
 		var $selectlist = $(html).find('#MySelectlist').selectlist();
 		$selectlist.selectlist('disable');


### PR DESCRIPTION
Fixes #1349 by checking to see if `li` are present and disabling itself if there are none or only one single item.

What's the point of selectlist with 1 item or no items?

Also implements an empty list label API:

```
var $selectlist = $(html).find('#selectlistEmpty').selectlist({
	emptyLabelHTML: '<li data-value=""><a href="#">I am feeling so empty</a></li>'
});
```

This is getting a little imperative with the `emptyLabelHTML`.

**UPDATED:** Design prefers to behave as a native `select` element and still allow the dropdown if only a single item exists.