### PR TITLE
If combobox dropdown is empty, disable the dropdown only

### DIFF
--- a/js/combobox.js
+++ b/js/combobox.js
@@ -43,6 +43,13 @@
 
 		// set default selection
 		this.setDefaultSelection();
+
+		// if dropdown is empty, disable it
+		var items = this.$dropMenu.children('li');
+		if( items.length === 0) {
+			this.$button.addClass('disabled');
+		}
+
 	};
 
 	Combobox.prototype = {

--- a/test/combobox-test.js
+++ b/test/combobox-test.js
@@ -23,6 +23,12 @@ define(function(require){
 		ok($combobox.combobox() === $combobox , 'combobox should be initialized');
 	});
 
+	test("should disable dropdown menu if no items exists", function () {
+		var $combobox = $(html).find('#MyComboboxSingleItem').combobox();
+		console.log($combobox.find('.btn'));
+		equal($combobox.find('.btn').hasClass('disabled'), true, 'dropdown disabled');
+	});
+
 	test("should set disabled state", function () {
 		var $combobox = $(html).find("#MyCombobox").combobox();
 		$combobox.combobox('disable');

--- a/test/markup/combobox-markup.html
+++ b/test/markup/combobox-markup.html
@@ -25,6 +25,19 @@
 		</div>
 	</div>
 
+	<div id="MyComboboxSingleItem" class="input-group input-append dropdown combobox">
+		<input id="MyComboBoxInput" type="text" class="form-control">
+		<div class="input-group-btn">
+			<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+				<span class="caret"></span>
+				<span class="sr-only">Toggle Dropdown</span>
+			</button>
+			<ul class="dropdown-menu dropdown-menu-right" aria-hidden="true" role="menu">
+			</ul>
+		</div>
+	</div>
+
+
 	<div class="form-group">
 		<label class="col-sm-2 control-label" for="MyComboBoxInput">No selected item</label>
 		<div class="col-sm-10">


### PR DESCRIPTION
Fixes #1349 by checking to see if `li` are present and disabling dropdown only if there are none. Input still works.