### PR TITLE
Focus on first matching item when key is pressed

### DIFF
--- a/js/selectlist.js
+++ b/js/selectlist.js
@@ -42,6 +42,30 @@
 		if (options.resize === 'auto' || this.$element.attr('data-resize') === 'auto') {
 			this.resize();
 		}
+
+		// support jumping focus to first letter in dropdown when key is pressed
+		this.$element.on('shown.bs.dropdown', function () {
+				var $this = $(this);
+				// attach key listener when dropdown is shown
+				$(document).on('keypress.fu.selectlist', function(e){
+					
+					// get the key that was pressed
+					var key = String.fromCharCode(e.which);
+					// look the items to find the first item with the first character match and set focus
+					$this.find("li").each(function(idx,item){
+						if ($(item).text().charAt(0).toLowerCase() === key) {
+							$(item).children('a').focus();
+							return false;
+						}
+					});
+					
+			});
+		});
+
+		// unbind key event when dropdown is hidden
+		this.$element.on('hide.bs.dropdown', function () {
+				$(document).off('keypress.fu.selectlist');
+		});
 	};
 
 	Selectlist.prototype = {


### PR DESCRIPTION
Fixes #128

I've made the mistake of thinking I could jump down to the next item when I pressed a key before in a custom selectlist. This allows a feature that the native `select` supports. When the dropdown is open pressing a letter will search the dropdown list until the first item starting with that letter is found and set the focus to that `a` tag. 

@jamin-hall Do we want to support this?