### PR TITLE
Allow empty string (ISO 8601) in datepicker momentJS format

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 					jquery: 'bower_components/jquery/dist/jquery',
 					underscore: 'bower_components/underscore/underscore',
 					bootstrap: 'bower_components/bootstrap/dist/js/bootstrap',
-					//moment: 'bower_components/moment/min/moment-with-locales',
+					moment: 'bower_components/moment/min/moment-with-locales',
 					fuelux: 'js'
 				},
 				shim: {

--- a/index.js
+++ b/index.js
@@ -105,12 +105,29 @@ define(function (require) {
 		DATEPICKER
 	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
+	function formatClientTimezone8601() {
+		var now = new Date(),
+				tzo = now.getTimezoneOffset() * -1,	//invert
+				dif = tzo >= 0 ? '+' : '-',
+				pad = function(num) {
+						var norm = Math.abs(Math.floor(num));
+						return (norm < 10 ? '0' : '') + norm;
+				};
+		return dif + pad(tzo / 60) + ':' + pad(tzo % 60);
+	}
+
+	var localTimezone = formatClientTimezone8601();
+
 	// initialize
 	$('#myDatepicker').datepicker({
+		momentConfig: {
+			culture: 'en',
+			format: ''
+		},
 		allowPastDates: true,
 		restricted: [{
-			from: '08/10/2014',
-			to: '08/15/2014'
+			from: '2014-08-10T00:00:00' + localTimezone,
+			to: '2014-08-15T00:00:00' + localTimezone
 		}]
 	});
 

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -161,7 +161,7 @@
 			if (
 			($.isFunction(window.moment) || (typeof moment !== 'undefined' && $.isFunction(moment))) &&
 				$.isPlainObject(this.options.momentConfig) &&
-				this.options.momentConfig.culture && this.options.momentConfig.format
+				(typeof this.options.momentConfig.culture === 'string' && typeof this.options.momentConfig.format === 'string')
 			) {
 				return true;
 			} else {

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -256,10 +256,19 @@ define(function(require){
 			});
 			var result4 = $datepicker4.datepicker('checkForMomentJS');
 
+			var $datepicker5 = $(html).datepicker({
+				momentConfig: {
+					culture: 'en',
+					formatCode: ''
+				}
+			});
+			var result5 = $datepicker5.datepicker('checkForMomentJS');
+
 			equal(result1, false, 'moment is not used because the option momentConfig.culture is null');
 			equal(result2, false, 'moment is not used because the option momentConfig.format is null');
 			equal(result3, false, 'moment is not used because the options momentConfig.culture and momentConfig.format are null');
 			equal(result4, true, 'moment is used because both momentConfig options are set');
+			equal(result5, true, 'moment is used because both momentConfig options are set, formatCode is empty');
 		});
 
 		test('should be initialized with different culture', function(){


### PR DESCRIPTION
Format can be an empty string because that is the API for the ISO 8601 format in MomentJS.