### PR TITLE
Re-render repeater column headings if headings are not present

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -606,7 +606,8 @@
 
 	function renderThead ($table, data) {
 		var columns = data.columns || [];
-		var i, j, l, $thead, $tr;
+		var $thead = $table.find('thead');
+		var i, j, l, $tr;
 
 		function differentColumns (oldCols, newCols) {
 			if (!newCols) {
@@ -631,8 +632,8 @@
 			return false;
 		}
 
-		if (this.list_firstRender || differentColumns(this.list_columns, columns)) {
-			$table.find('thead').remove();
+		if (this.list_firstRender || differentColumns(this.list_columns, columns) || $thead.length === 0) {
+			$thead.remove();
 
 			this.list_columns = columns;
 			this.list_firstRender = false;


### PR DESCRIPTION
Fixes #1385
corrects issue by re-rendering headers if thead is not found