### PR TITLE
Allow repeater views without period and subviews within setViewOptions

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -726,7 +726,7 @@
 			var opts = {};
 			var viewName = curView.split('.')[1];
 
-			if (viewName && this.options.views) {
+			if (this.options.views) {
 				opts = this.options.views[viewName] || this.options.views[curView] || {};
 			} else {
 				opts = {};


### PR DESCRIPTION
Fixes #1387
Corrected the logic bug in setViewOptions preventing correct attribute in the views config options from being used