### PR TITLE
Remove bower from npm postinstall

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -88,7 +88,7 @@ Fuel UX is lightweight to give you a fast dependable foundation to build upon. I
 From the command line:
 
 1. Install `grunt-cli` globally with `npm install -g grunt-cli`.
-2. Make sure you're in the root of the fuel directory, then run `npm install`. npm will look at [package.json](https://github.com/exacttarget/fuelux/blob/master/package.json) and automatically install the necessary local dependencies listed there.
+2. Make sure you're in the root of the fuel directory, then run `npm install`. npm will look at [package.json](https://github.com/exacttarget/fuelux/blob/master/package.json) and automatically install the necessary local dependencies listed there. Finally, run `bower install` to install front-end dependencies.
 
 When completed, you'll be able to run the various Grunt commands provided from the command line.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Ensure all the dependencies are included on the page (eg, such as using the CDN 
 A few ways available to install.
 
 - Request files from [the Fuel UX CDN](http://www.fuelcdn.com/fuelux/3.10.0/)
+- Install with [NPM](https://www.npmjs.com/package/fuelux): `npm install fuelux`.
 - [Download the latest release](https://github.com/exacttarget/fuelux/archive/3.4.0.zip).
 - Clone the repo: `git clone https://github.com/exacttarget/fuelux.git`.
 - Install with [Bower](http://bower.io): `bower install fuelux`.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "scripts": {
     "main": "devserver.js",
-    "postinstall": "node ./node_modules/bower/bin/bower install",
     "start": "grunt serve",
     "test": "grunt travisci --verbose"
   },


### PR DESCRIPTION
- Causing installation errors now that Fuel UX supports `npm`, since bower is no longer in production dependencies and `npm install` is used when fuelux is used as a dependency itself.
- Now explicitly says to run `bower install` after `npm install` in `DETAILS.md`