### PR TITLE
Add glyphicons to example page

### DIFF
--- a/index.js
+++ b/index.js
@@ -734,19 +734,19 @@ define(function (require) {
 					{
 						name: 'edit',
 						html: function () {
-							return '<div class="fuelux-icon fuelux-icon-pencil"></div> Edit'
+							return '<span class="glyphicon glyphicon-pencil"></span> Edit'
 						}
 					},
 					{
 						name: 'copy',
 						html: function () {
-							return '<div class="fuelux-icon fuelux-icon-copy"></div> Copy'
+							return '<span class="glyphicon glyphicon-copy"></span> Copy'
 						}
 					},
 					{
 						name: 'delete',
 						html: function () {
-							return '<div class="fuelux-icon fuelux-icon-delete"></div> Delete'
+							return '<span class="glyphicon glyphicon-trash"></span> Delete'
 						},
 						clickAction: function(helpers, callback) {
 							console.log('hey it worked');


### PR DESCRIPTION
Fuel UX does not support MC theme icons. 

Also, `<span>` is typically used within `<a>` and with icons in Bootstrap and Fuel UX.