### PR TITLE
Transformed postinstall bash script into node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "main": "devserver.js",
     "start": "grunt serve",
     "test": "grunt travisci --verbose",
-    "postinstall": "./postinstall.sh"
+    "postinstall": "node postinstall.js"
   },
   "title": "Fuel UX",
   "version": "3.11.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,4 @@
+
+if (process.env.INSTALL_BOWER === 'true') {
+   require("bower").commands.install();
+}

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if [ "$INSTALL_BOWER" = "true" ]; then
- 	node ./node_modules/bower/bin/bower install
-fi


### PR DESCRIPTION
This way, bower can be installed on any platform.

I used bower's programmatic API. I doubt the API will change since we are using the plain install command. 

If concerned, it could be turned into a native OS process launch to run `bower install`.