### PR TITLE
Prevent repeat selectlist from being undefined in scheduler

### DIFF
--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -379,8 +379,8 @@
 
 			if (!data) {
 				selectedItem = this.$repeatIntervalSelect.selectlist('selectedItem');
-				val = selectedItem.value;
-				txt = selectedItem.text;
+				val = selectedItem.value || "";
+				txt = selectedItem.text || "";
 			} else {
 				val = data.value;
 				txt = data.text;


### PR DESCRIPTION
Accounts for selectlist not guaranteeing that 'selectedItem' will have defined value or text properties