### PR TITLE
Allow default unit to be added to spinbox if not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -894,11 +894,11 @@ define(function (require) {
 
 	// intitalize control
 	$('#mySpinbox2').spinbox({
-		value: '10px',
+		value: '1,0px',
 		min: 0,
 		max: 10,
 		step: 0.1,
-		// decimalMark: ',',
+		decimalMark: ',',
 		units: ['px'],
 		defaultUnit: 'px'
 	});

--- a/index.js
+++ b/index.js
@@ -894,12 +894,13 @@ define(function (require) {
 
 	// intitalize control
 	$('#mySpinbox2').spinbox({
-		value: '1,0px',
+		value: '10 px',
 		min: 0,
 		max: 10,
 		step: 0.1,
-		decimalMark: ',',
-		units: ['px']
+		// decimalMark: ',',
+		units: ['px'],
+		defaultUnit: 'px'
 	});
 
 	// events

--- a/index.js
+++ b/index.js
@@ -894,7 +894,7 @@ define(function (require) {
 
 	// intitalize control
 	$('#mySpinbox2').spinbox({
-		value: '10 px',
+		value: '10px',
 		min: 0,
 		max: 10,
 		step: 0.1,

--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -131,7 +131,7 @@
 			// if set and default unit if not already present, 
 			// and is an allowed unit, then add default unit
 			if (this.options.defaultUnit !== '' && 
-					this.options.defaultUnit !== value.slice(-2) &&
+					this.options.defaultUnit !== value.slice(-Math.abs(this.options.defaultUnit.length)) &&
 					this.isUnitLegal(this.options.defaultUnit)) {
 				value = value + this.options.defaultUnit;
 			}

--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -128,6 +128,10 @@
 
 		output: function (value, updateField) {
 			value = (value + '').split('.').join(this.options.decimalMark);
+			// if set and default unit if not already present, add default unit
+			if (this.options.defaultUnit !== '' && this.options.defaultUnit !== value.slice(-2)) {
+				value = value + this.options.defaultUnit;
+			}
 			updateField = (updateField || true);
 			if (updateField) {
 				this.$input.val(value);
@@ -420,7 +424,8 @@
 		disabled: false,
 		cycle: false,
 		units: [],
-		decimalMark: '.'
+		decimalMark: '.',
+		defaultUnit: ''
 	};
 
 	$.fn.spinbox.Constructor = Spinbox;

--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -128,8 +128,11 @@
 
 		output: function (value, updateField) {
 			value = (value + '').split('.').join(this.options.decimalMark);
-			// if set and default unit if not already present, add default unit
-			if (this.options.defaultUnit !== '' && this.options.defaultUnit !== value.slice(-2)) {
+			// if set and default unit if not already present, 
+			// and is an allowed unit, then add default unit
+			if (this.options.defaultUnit !== '' && 
+					this.options.defaultUnit !== value.slice(-2) &&
+					this.isUnitLegal(this.options.defaultUnit)) {
 				value = value + this.options.defaultUnit;
 			}
 			updateField = (updateField || true);

--- a/test/spinbox-test.js
+++ b/test/spinbox-test.js
@@ -150,6 +150,17 @@ define(function(require){
 
 	});
 
+	test("spinbox should add default unit if none is specified", function () {
+		var $spinbox = $(html).find('#MySpinbox').spinbox({
+			units: ['px'],
+			defaultUnit: 'px'
+		});
+
+		$spinbox.spinbox('value', 1);
+		ok($spinbox.spinbox('value') === '1px', 'spinbox returned value with default unit');
+
+	});
+
 	test("spinbox should behave correctly when custom decimalMark is used", function () {
 		var $spinbox = $(html).find('#MySpinboxDecimal').spinbox({
 			value: '1,1',

--- a/test/spinbox-test.js
+++ b/test/spinbox-test.js
@@ -161,7 +161,7 @@ define(function(require){
 
 	});
 
-	test("spinbox should not add default unit if it not allowed", function () {
+	test("spinbox should NOT add default unit if it not allowed", function () {
 		var $spinbox = $(html).find('#MySpinbox').spinbox({
 			units: ['px'],
 			defaultUnit: 'ouch'
@@ -169,6 +169,19 @@ define(function(require){
 
 		$spinbox.spinbox('value', 1);
 		ok($spinbox.spinbox('value') === '1', 'spinbox returned value WITHOUT default unit');
+
+	});
+
+	test("spinbox should keep 3 character default unit when incremented", function () {
+		var $spinbox = $(html).find('#MySpinbox').spinbox({
+			units: ['rem', 'px', '%'],
+			step: 1, // default, but explicit
+			defaultUnit: 'rem'
+		});
+
+		$spinbox.spinbox('value', 1);
+		$spinbox.spinbox('step', true);
+		ok($spinbox.spinbox('value') === '2rem', 'spinbox returned value with default unit');
 
 	});
 

--- a/test/spinbox-test.js
+++ b/test/spinbox-test.js
@@ -161,6 +161,17 @@ define(function(require){
 
 	});
 
+	test("spinbox should not add default unit if it not allowed", function () {
+		var $spinbox = $(html).find('#MySpinbox').spinbox({
+			units: ['px'],
+			defaultUnit: 'ouch'
+		});
+
+		$spinbox.spinbox('value', 1);
+		ok($spinbox.spinbox('value') === '1', 'spinbox returned value WITHOUT default unit');
+
+	});
+
 	test("spinbox should behave correctly when custom decimalMark is used", function () {
 		var $spinbox = $(html).find('#MySpinboxDecimal').spinbox({
 			value: '1,1',


### PR DESCRIPTION
I'd call this a bug, since I think spinbox was meant to work this way, but it is a new initialization option.

Fixes #1490.