### PR TITLE
Allow Datepicker to handle two-digit year with MomentJS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "jquery": "latest",
     "requirejs": "2.x",
     "bootstrap": "3.x",
-    "moment": "2.x"
+    "moment": "~2.10.6"
   },
   "devDependencies": {
     "jquery": null,

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "jquery": "latest",
     "requirejs": "2.x",
     "bootstrap": "3.x",
-    "moment": "2.x"
+    "moment": "^2.10.6"
   },
   "devDependencies": {
     "jquery": null,

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "jquery": "latest",
     "requirejs": "2.x",
     "bootstrap": "3.x",
-    "moment": "~2.10.6"
+    "moment": "2.x"
   },
   "devDependencies": {
     "jquery": null,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "bootstrap": "3.x",
     "jquery": "2.x",
-    "moment": "2.x"
+    "moment": "^2.10.6"
   },
   "description": "Base Fuel UX styles and controls",
   "devDependencies": {

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -83,22 +83,22 @@ define(function(require){
 			$datepickerInput.val('01/01/68');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/1968', '01/01/68 parsed correctly');
+			equal(parsedAs, '01/01/2068', '01/01/68 parsed correctly');
 
 			$datepickerInput.val('1/1/68');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/1968', '1/1/68 parsed correctly');
+			equal(parsedAs, '01/01/2068', '1/1/68 parsed correctly');
 
 			$datepickerInput.val('1/1/69');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/2069', '1/1/69 parsed correctly');
+			equal(parsedAs, '01/01/1969', '1/1/69 parsed correctly');
 
 			$datepickerInput.val('01/01/69');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/2069', '01/01/69 parsed correctly');
+			equal(parsedAs, '01/01/1969', '01/01/69 parsed correctly');
 		});
 
 		test('should initialize with null date', function(){

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -101,27 +101,6 @@ define(function(require){
 			equal(parsedAs, '01/01/1980', '01/01/80 parsed correctly');
 		});
 
-		test('should not handle accommodate 2 digit year', function(){
-			var $datepicker = $(html).datepicker({twoDigitYearProtection: false});
-			var $datepickerInput = $datepicker.find('input');
-			var parsedAs;
-
-			$datepickerInput.val('01/01/15');
-			$datepickerInput.trigger('change');
-			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/0015', '01/01/15 parsed incorrectly correctly');
-
-			$datepickerInput.val('1/1/15');
-			$datepickerInput.trigger('change');
-			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/0015', '1/1/15 parsed incorrectly correctly');
-
-			$datepickerInput.val('01/01/80');
-			$datepickerInput.trigger('change');
-			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/0080', '01/01/80 parsed incorrectly correctly');
-		});
-
 		test('should initialize with null date', function(){
 			var $datepicker = $(html).datepicker({ date: null });
 			var initializedDate = $datepicker.datepicker('getDate').toString();

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -80,25 +80,25 @@ define(function(require){
 			var $datepickerInput = $datepicker.find('input');
 			var parsedAs;
 
-			$datepickerInput.val('01/01/15');
+			$datepickerInput.val('01/01/68');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/2015', '01/01/15 parsed correctly');
+			equal(parsedAs, '01/01/1968', '01/01/68 parsed correctly');
 
-			$datepickerInput.val('1/1/2015');
+			$datepickerInput.val('1/1/68');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/2015', '1/1/2015 parsed correctly');
+			equal(parsedAs, '01/01/1968', '1/1/68 parsed correctly');
 
-			$datepickerInput.val('1/1/15');
+			$datepickerInput.val('1/1/69');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/2015', '1/1/15 parsed correctly');
+			equal(parsedAs, '01/01/2069', '1/1/69 parsed correctly');
 
-			$datepickerInput.val('01/01/80');
+			$datepickerInput.val('01/01/69');
 			$datepickerInput.trigger('change');
 			parsedAs = $datepicker.datepicker('getFormattedDate');
-			equal(parsedAs, '01/01/1980', '01/01/80 parsed correctly');
+			equal(parsedAs, '01/01/2069', '01/01/69 parsed correctly');
 		});
 
 		test('should initialize with null date', function(){

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -75,6 +75,53 @@ define(function(require){
 			equal(pickerDate.getTime(), futureDate, 'markup datepicker initialized with different date than now');
 		});
 
+		test('should handle 2 digit year', function(){
+			var $datepicker = $(html).datepicker();
+			var $datepickerInput = $datepicker.find('input');
+			var parsedAs;
+
+			$datepickerInput.val('01/01/15');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/2015', '01/01/15 parsed correctly');
+
+			$datepickerInput.val('1/1/2015');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/2015', '1/1/2015 parsed correctly');
+
+			$datepickerInput.val('1/1/15');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/2015', '1/1/15 parsed correctly');
+
+			$datepickerInput.val('01/01/80');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/1980', '01/01/80 parsed correctly');
+		});
+
+		test('should not handle accommodate 2 digit year', function(){
+			var $datepicker = $(html).datepicker({twoDigitYearProtection: false});
+			var $datepickerInput = $datepicker.find('input');
+			var parsedAs;
+
+			$datepickerInput.val('01/01/15');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/0015', '01/01/15 parsed incorrectly correctly');
+
+			$datepickerInput.val('1/1/15');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/0015', '1/1/15 parsed incorrectly correctly');
+
+			$datepickerInput.val('01/01/80');
+			$datepickerInput.trigger('change');
+			parsedAs = $datepicker.datepicker('getFormattedDate');
+			equal(parsedAs, '01/01/0080', '01/01/80 parsed incorrectly correctly');
+		});
+
 		test('should initialize with null date', function(){
 			var $datepicker = $(html).datepicker({ date: null });
 			var initializedDate = $datepicker.datepicker('getDate').toString();


### PR DESCRIPTION
fixes #1483
