### PR TITLE
Add generate release notes task to release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ stage.sh
 publish.sh
 
 # github token
-github.token
+GITHUB_TOKEN.json

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
 			command: function() {
 				grunt.config('release.localBranch', 'release_' + new Date().getTime() );
 				var command = [
-					'git fetch ' + grunt.config('release.remoteRepository') + ' --tags',
+					'git fetch --tags ' + grunt.config('release.remoteRepository'),
 					'git fetch ' + grunt.config('release.remoteRepository'),
 					'git checkout -b ' + grunt.config('release.localBranch') + ' ' +
 						grunt.config('release.remoteRepository') + '/' + grunt.config('release.remoteBaseBranch')

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -7,7 +7,7 @@ module.exports = function (grunt) {
 	}
 
 	function getGithubToken() {
-		return grunt.file.readJSON('./GITHUB_TOKEN.json').token;
+		return grunt.file.exists('./GITHUB_TOKEN.json') ? grunt.file.readJSON('./GITHUB_TOKEN.json').token : '';
 	}
 
 	return {

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -1,5 +1,6 @@
 module.exports = function (grunt) {
 	var semver = require('semver');
+	var originalVersion = grunt.file.readJSON('./package.json').version;
 
 	function getPackage() {
 		return grunt.file.readJSON('./package.json');
@@ -10,10 +11,9 @@ module.exports = function (grunt) {
 	}
 
 	return {
-		// Compile release notes while waiting for tests to pass. Needs Ruby gem and ONLY LOOKS AT THE REMOTE NAMED ORIGIN.
 		// Install with: gem install github_changelog_generator
 		notes: {
-			command: 'github_changelog_generator --no-author --unreleased-only --compare-link -t ' + getGithubToken()
+			command: 'github_changelog_generator --no-author --between-tags ' + originalVersion + ',' + getPackage().version + ' --compare-link -t ' + getGithubToken()
 		},
 		checkoutRemoteReleaseBranch: {
 			// this makes a local branch based on the prior prompt, such as release_{TIMESTAMP}

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -21,7 +21,8 @@ module.exports = function (grunt) {
 			command: function() {
 				grunt.config('release.localBranch', 'release_' + new Date().getTime() );
 				var command = [
-					'git fetch ' + grunt.config('release.remoteRepository') + ' --tag',
+					'git fetch ' + grunt.config('release.remoteRepository') + ' --tags',
+					'git fetch ' + grunt.config('release.remoteRepository'),
 					'git checkout -b ' + grunt.config('release.localBranch') + ' ' +
 						grunt.config('release.remoteRepository') + '/' + grunt.config('release.remoteBaseBranch')
 				].join(' && ');

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -5,11 +5,15 @@ module.exports = function (grunt) {
 		return grunt.file.readJSON('./package.json');
 	}
 
+	function getGithubToken() {
+		return grunt.file.readJSON('./GITHUB_TOKEN.json').token;
+	}
+
 	return {
 		// Compile release notes while waiting for tests to pass. Needs Ruby gem and ONLY LOOKS AT THE REMOTE NAMED ORIGIN.
 		// Install with: gem install github_changelog_generator
 		notes: {
-			command: 'github_changelog_generator --no-author --unreleased-only --compare-link'
+			command: 'github_changelog_generator --no-author --unreleased-only --compare-link -t ' + getGithubToken()
 		},
 		checkoutRemoteReleaseBranch: {
 			// this makes a local branch based on the prior prompt, such as release_{TIMESTAMP}
@@ -17,9 +21,9 @@ module.exports = function (grunt) {
 			command: function() {
 				grunt.config('release.localBranch', 'release_' + new Date().getTime() );
 				var command = [
+					'git fetch ' + grunt.config('release.remoteRepository') + ' --tag',
 					'git checkout -b ' + grunt.config('release.localBranch') + ' ' +
-						grunt.config('release.remoteRepository') + '/' + grunt.config('release.remoteBaseBranch'),
-						'git fetch ' + grunt.config('release.remoteRepository') + ' --tag'
+						grunt.config('release.remoteRepository') + '/' + grunt.config('release.remoteBaseBranch')
 				].join(' && ');
 				grunt.log.write('Checking out new local branch based on ' + grunt.config('release.remoteBaseBranch') + ': ' + command);
 				return command;

--- a/grunt/tasks/release.js
+++ b/grunt/tasks/release.js
@@ -48,7 +48,6 @@ module.exports = function(grunt) {
 				'shell:checkoutRemoteReleaseBranch',
 				'updateRelease',
 				'prompt:build',
-				'prompt:generatelogs',
 				'dorelease'
 			]
 		);
@@ -71,7 +70,7 @@ module.exports = function(grunt) {
 		// Run dist again to grab the latest version numbers. Yeah, we're running it twice... ¯\_(ツ)_/¯
 		grunt.task.run(['bump-only:' + grunt.config('release.buildSemVerType'), 'replace:readme', 'dist',
 			'shell:addReleaseFiles', 'prompt:commit', 'prompt:tag', 'prompt:pushLocalBranchToUpstream',
-			'prompt:pushTagToUpstream', 'prompt:uploadToCDN', 'prompt:pushLocalBranchToUpstreamMaster', 'shell:publishToNPM']);
+			'prompt:pushTagToUpstream', 'prompt:uploadToCDN', 'prompt:pushLocalBranchToUpstreamMaster', 'shell:publishToNPM', 'prompt:generatelogs']);
 	});
 
 


### PR DESCRIPTION
Adds github API token file (must be created by maintainer via Github profile) and add generate release logs task to release workflow.