### PR TITLE
Correcting outdated placard markup

### DIFF
--- a/_includes/js/placard.html
+++ b/_includes/js/placard.html
@@ -58,7 +58,7 @@
 <div class="placard" data-ellipsis="true" data-initialize="placard" id="myPlacard4">
   <div class="placard-popup"></div>
   <div class="placard-header"><h5>Header</h5></div>
-  <textarea class="form-control placard-field" readonly="readonly"></textarea>
+  <textarea class="form-control placard-field"></textarea>
   <div class="placard-footer">
     <a class="placard-cancel" href="#">Cancel</a>
     <button class="btn btn-primary btn-xs placard-accept" type="button">Save</button>


### PR DESCRIPTION
fixes #1495 by removing readonly="readonly" from the placard markup example