### PR TITLE
Correcting Tree documentation markup order

### DIFF
--- a/_includes/js/tree.html
+++ b/_includes/js/tree.html
@@ -252,57 +252,10 @@ $('#myTree').on('selected.fu.tree', function (event, data) {
   <p>Tree provides a categorical element selection. Use it to create a file system interface. Wrap the wrapper tree containers with <code>.fuelux .tree</code></p>
 
   <div class="form-group">
-    <label class="control-label">Items selectable only</label>
-    <p>Please note the location of <code>.glyphicon-play</code> <em>inside</em> <code>.tree-branch-name</code>.</p>
-    <div class="form-group">
-
-      <ul class="tree" role="tree" id="myTree">
-        <li class="tree-branch hide" data-template="treebranch" role="treeitem" aria-expanded="false">
-          <div class="tree-branch-header">
-            <button type="button" class="tree-branch-name">
-              <span class="glyphicon icon-caret glyphicon-play"></span>
-              <span class="glyphicon icon-folder glyphicon-folder-close"></span>
-              <span class="tree-label"></span>
-            </button>
-          </div>
-          <ul class="tree-branch-children" role="group"></ul>
-          <div class="tree-loader" role="alert">Loading...</div>
-        </li>
-        <li class="tree-item hide" data-template="treeitem" role="treeitem">
-          <button type="button" class="tree-item-name">
-            <span class="glyphicon icon-item fueluxicon-bullet"></span>
-            <span class="tree-label"></span>
-          </button>
-        </li>
-      </ul>
-
-    </div>
-  </div>
-{% highlight html %}
-<ul class="tree" role="tree" id="myTree">
-  <li class="tree-branch hide" data-template="treebranch" role="treeitem" aria-expanded="false">
-    <div class="tree-branch-header">
-      <button type="button" class="tree-branch-name">
-        <span class="glyphicon icon-caret glyphicon-play"></span>
-        <span class="glyphicon icon-folder glyphicon-folder-close"></span>
-        <span class="tree-label"></span>
-      </button>
-    </div>
-    <ul class="tree-branch-children" role="group"></ul>
-    <div class="tree-loader" role="alert">Loading...</div>
-  </li>
-  <li class="tree-item hide" data-template="treeitem" role="treeitem">
-    <button type="button" class="tree-item-name">
-      <span class="glyphicon icon-item fueluxicon-bullet"></span>
-      <span class="tree-label"></span>
-    </button>
-  </li>
-</ul>
-{% endhighlight %}
-
-  <div class="form-group">
     <label class="control-label">Folders selectable</label>
-    <p>Please note the location of <code>.glyphicon-play</code> <em>outside</em> <code>.tree-branch-name</code>.</p>
+    <p>Please note the location of <code>.glyphicon-play</code> <em>outside</em> <code>.tree-branch-name</code>. The control
+      allows folders to be selected by default unless the <code>folderSelect</code> option is set to <code>false</code>,
+      which then requires slightly different markup ("Items selectable only," shown further below)</p>
     <div class="form-group">
 
       <ul class="tree tree-folder-select" role="tree" id="myTreeSelectableFolder">
@@ -350,5 +303,55 @@ $('#myTree').on('selected.fu.tree', function (event, data) {
 </ul>
 {% endhighlight %}
 
+
+  <div class="form-group">
+    <label class="control-label">Items selectable only</label>
+    <p>Please note the location of <code>.glyphicon-play</code> <em>inside</em> <code>.tree-branch-name</code>. This markup
+    is used if the <code>folderSelect</code> option is set to <code>false</code>.</p>
+    <div class="form-group">
+
+      <ul class="tree" role="tree" id="myTree">
+        <li class="tree-branch hide" data-template="treebranch" role="treeitem" aria-expanded="false">
+          <div class="tree-branch-header">
+            <button type="button" class="tree-branch-name">
+              <span class="glyphicon icon-caret glyphicon-play"></span>
+              <span class="glyphicon icon-folder glyphicon-folder-close"></span>
+              <span class="tree-label"></span>
+            </button>
+          </div>
+          <ul class="tree-branch-children" role="group"></ul>
+          <div class="tree-loader" role="alert">Loading...</div>
+        </li>
+        <li class="tree-item hide" data-template="treeitem" role="treeitem">
+          <button type="button" class="tree-item-name">
+            <span class="glyphicon icon-item fueluxicon-bullet"></span>
+            <span class="tree-label"></span>
+          </button>
+        </li>
+      </ul>
+
+    </div>
+  </div>
+  {% highlight html %}
+  <ul class="tree" role="tree" id="myTree">
+    <li class="tree-branch hide" data-template="treebranch" role="treeitem" aria-expanded="false">
+      <div class="tree-branch-header">
+        <button type="button" class="tree-branch-name">
+          <span class="glyphicon icon-caret glyphicon-play"></span>
+          <span class="glyphicon icon-folder glyphicon-folder-close"></span>
+          <span class="tree-label"></span>
+        </button>
+      </div>
+      <ul class="tree-branch-children" role="group"></ul>
+      <div class="tree-loader" role="alert">Loading...</div>
+    </li>
+    <li class="tree-item hide" data-template="treeitem" role="treeitem">
+      <button type="button" class="tree-item-name">
+        <span class="glyphicon icon-item fueluxicon-bullet"></span>
+        <span class="tree-label"></span>
+      </button>
+    </li>
+  </ul>
+  {% endhighlight %}
 
 </div>


### PR DESCRIPTION
fixes #1336 by rearranging tree documentation markup order to match default behavior and providing additional explanation of markup