### PR TITLE
Allow window override in dropdown auto-flip

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,9 +404,9 @@
 						<div class="input-group input-append dropdown combobox" data-initialize="combobox" id="myCombobox">
 							<input type="text" class="form-control">
 							<div class="input-group-btn">
-								<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"><span class="caret"></span>
+								<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" data-flip="auto"><span class="caret"></span>
 								</button>
-								<ul class="dropdown-menu dropdown-menu-right" role="menu">
+								<ul class="dropdown-menu dropdown-menu-right" data-target="window" role="menu">
 									<li data-value="1"><a href="#">One</a>
 									</li>
 									<li data-value="2"><a href="#">Two</a>

--- a/js/dropdown-autoflip.js
+++ b/js/dropdown-autoflip.js
@@ -97,31 +97,33 @@
 	}
 
 	function _getContainer(element) {
-		var containerElement, isWindow;
+		var targetSelector = element.attr('data-target');
+		var isWindow = true;
+		var containerElement;
 
-		// manual override
-		if (element.attr('data-target')) {
-			containerElement = element.attr('data-target');
-			isWindow = false;
-		} else {
-			// default to window otherwise
-			containerElement = window;
-			isWindow = true;
-
-			// unless there's a parent element with non-visible overflow
-			$.each(element.parents(), function (index, value) {
-				if ($(value).css('overflow') !== 'visible') {
-					containerElement = value;
+		if(!targetSelector) {
+			// no selection so find the relevant ancestor
+			$.each(element.parents(), function (index, parentElement) {
+				if ($(parentElement).css('overflow') !== 'visible') {
+					containerElement = parentElement;
 					isWindow = false;
 					return false;
 				}
 			});
+		}
+		else if (targetSelector !== 'window') {
+			containerElement = $(targetSelector);
+			isWindow = false;
+		}
 
+		// fallback to window
+		if (isWindow) {
+			containerElement = window;
 		}
 
 		return {
-			overflowElement: $(containerElement),
-			isWindow: isWindow
+				overflowElement: $(containerElement),
+				isWindow: isWindow
 		};
 	}
 


### PR DESCRIPTION
This allows explicitly setting auto-flip container to window via `data-target=window`.