### PR TITLE
support `end === true` attribute to prevent infinite scroll datasource call (fix #1605)

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -366,7 +366,7 @@
 
 			this.currentPage = (page !== undefined) ? page : NaN;
 
-			if (data.end || (this.currentPage + 1) >= pages) {
+			if (data.end === true || (this.currentPage + 1) >= pages) {
 				this.infiniteScrollingCont.infinitescroll('end', end);
 			}
 		},

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -366,7 +366,7 @@
 
 			this.currentPage = (page !== undefined) ? page : NaN;
 
-			if ((this.currentPage + 1) >= pages) {
+			if (data.end || (this.currentPage + 1) >= pages) {
 				this.infiniteScrollingCont.infinitescroll('end', end);
 			}
 		},
@@ -591,6 +591,7 @@
 				data = data || {};
 
 				if (self.infiniteScrollingEnabled) {
+					// pass empty object because data handled in infiniteScrollPaging method
 					self.infiniteScrollingCallback({});
 				} else {
 					self.itemization(data);


### PR DESCRIPTION
use [this](http://bl.ocks.org/swilliamset/9307df68bd231a414e27) for testing

it points to local build