### PR TITLE
Run `npm update` after wget on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 - time tar -zxf node_modules.tar.gz
 - chmod +x ./node_modules
 install:
+- time npm update
 - time ./node_modules/bower/bin/bower update
 env:
   global:


### PR DESCRIPTION
This should help tests run for @greenkeeperio-bot PR's that actually matter and use the versions that were changed.

Currently, we install a cached tarball of Node modules from our Heroku dev app / edge server, but it only gets updated after merges into master.