### PR TITLE
Scheduler: Weekdays frequency should be 'weekly' instead of 'daily'

### DIFF
--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -554,10 +554,14 @@
 				}
 
 				if (recur.FREQ === 'DAILY') {
-					if (recur.INTERVAL === '1' && recur.COUNT === '1') {
-						item = 'none';
+					if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
+							item = 'weekdays';
 					} else {
-						item = 'daily';
+						if (recur.INTERVAL === '1' && recur.COUNT === '1') {
+							item = 'none';
+						} else {
+							item = 'daily';
+						}
 					}
 				} else if (recur.FREQ === 'SECONDLY') {
 					item = 'secondly';

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -555,7 +555,7 @@
 
 				if (recur.FREQ === 'DAILY') {
 					if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
-							item = 'weekdays';
+						item = 'weekdays';
 					} else {
 						if (recur.INTERVAL === '1' && recur.COUNT === '1') {
 							item = 'none';

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -570,6 +570,8 @@
 				} else if (recur.FREQ === 'HOURLY') {
 					item = 'hourly';
 				} else if (recur.FREQ === 'WEEKLY') {
+					item = 'weekly';
+					
 					if (recur.BYDAY) {
 						if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
 							item = 'weekdays';
@@ -582,8 +584,6 @@
 							}
 						}
 					}
-
-					item = 'weekly';
 				} else if (recur.FREQ === 'MONTHLY') {
 					this.$element.find('.repeat-monthly input').removeAttr('checked').removeClass('checked');
 					this.$element.find('.repeat-monthly label.radio-custom').removeClass('checked');

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -576,11 +576,11 @@
 						if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
 							item = 'weekdays';
 						} else {
-							item = this.$element.find('.repeat-days-of-the-week .btn-group');
-							item.find('label').removeClass('active');
+							var el = this.$element.find('.repeat-days-of-the-week .btn-group');
+							el.find('label').removeClass('active');
 							temp = recur.BYDAY.split(',');
 							for (i = 0, l = temp.length; i < l; i++) {
-								item.find('input[data-value="' + temp[i] + '"]').prop('checked',true).parent().addClass('active');
+								el.find('input[data-value="' + temp[i] + '"]').prop('checked',true).parent().addClass('active');
 							}
 						}
 					}

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -554,11 +554,11 @@
 				}
 
 				if (recur.FREQ === 'DAILY') {
-						if (recur.INTERVAL === '1' && recur.COUNT === '1') {
-							item = 'none';
-						} else {
-							item = 'daily';
-						}
+					if (recur.INTERVAL === '1' && recur.COUNT === '1') {
+						item = 'none';
+					} else {
+						item = 'daily';
+					}
 				} else if (recur.FREQ === 'SECONDLY') {
 					item = 'secondly';
 				} else if (recur.FREQ === 'MINUTELY') {

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -554,15 +554,11 @@
 				}
 
 				if (recur.FREQ === 'DAILY') {
-					if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
-						item = 'weekdays';
-					} else {
 						if (recur.INTERVAL === '1' && recur.COUNT === '1') {
 							item = 'none';
 						} else {
 							item = 'daily';
 						}
-					}
 				} else if (recur.FREQ === 'SECONDLY') {
 					item = 'secondly';
 				} else if (recur.FREQ === 'MINUTELY') {
@@ -571,11 +567,15 @@
 					item = 'hourly';
 				} else if (recur.FREQ === 'WEEKLY') {
 					if (recur.BYDAY) {
-						item = this.$element.find('.repeat-days-of-the-week .btn-group');
-						item.find('label').removeClass('active');
-						temp = recur.BYDAY.split(',');
-						for (i = 0, l = temp.length; i < l; i++) {
-							item.find('input[data-value="' + temp[i] + '"]').prop('checked',true).parent().addClass('active');
+						if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
+							item = 'weekdays';
+						} else {
+							item = this.$element.find('.repeat-days-of-the-week .btn-group');
+							item.find('label').removeClass('active');
+							temp = recur.BYDAY.split(',');
+							for (i = 0, l = temp.length; i < l; i++) {
+								item.find('input[data-value="' + temp[i] + '"]').prop('checked',true).parent().addClass('active');
+							}
 						}
 					}
 

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -348,7 +348,7 @@
 				pattern += 'FREQ=DAILY;';
 				pattern += 'INTERVAL=' + interval + ';';
 			} else if (repeat === 'weekdays') {
-				pattern += 'FREQ=DAILY;';
+				pattern += 'FREQ=WEEKLY;';
 				pattern += 'BYDAY=MO,TU,WE,TH,FR;';
 				pattern += 'INTERVAL=1;';
 			} else if (repeat === 'weekly') {

--- a/test/scheduler-test.js
+++ b/test/scheduler-test.js
@@ -177,7 +177,7 @@ define(function(require){
 		$scheduler.scheduler('value', { recurrencePattern: 'FREQ=DAILY;INTERVAL=4' });
 		ok(($repIntSelDrop.html()==='Daily' && $repPanSpinbox.spinbox('value')==='4'), 'daily recurrence set correctly');
 
-		$scheduler.scheduler('value', { recurrencePattern: 'FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1' });
+		$scheduler.scheduler('value', { recurrencePattern: 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1' });
 		equal($repIntSelDrop.html(), 'Weekdays', 'weekday recurrence set correctly');
 
 		$scheduler.scheduler('value', { recurrencePattern: 'FREQ=WEEKLY;BYDAY=MO,TH;INTERVAL=7' });


### PR DESCRIPTION
When selecting 'Weekdays' as the repeat option of the scheduler control, the recurrencePattern is as follows:

`FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1`

when it should be:

`FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1`

This can be verified against the recurrencePattern that gets set if you choose 'Weekly' as the repeat option, and manually select each week day, as these are functionally identical.