### PR TITLE
using css instead of outerHeight to set height

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -139,7 +139,7 @@
 			$table.find('thead th').each(function () {
 				var $th = $(this);
 				var $heading = $th.find('.repeater-list-heading');
-				$heading.outerHeight($th.outerHeight());
+				$heading.css({ height: $th.outerHeight() });
 				$heading.outerWidth($heading.data('forced-width') || $th.outerWidth());
 			});
 		};


### PR DESCRIPTION
fixes #1634 

Setting using `.outerHeight()` instead of `.css({height:...})` breaks repeaters iframed in in firefox.

There is something really weird going on to where when you set using outerHeight, it takes the 12 pixels of padding and the 1 pixel of bottom border into account and changes the correct "33" to "20" and sets the css height property to 7 (because 7 + 13 pixels of calculated padding and border is 20). It's like it accounts for padding and margin coming out and going in, stripping them off twice for the final height set. This only occurs in Firefox in an iFrame, and I don't know why. But rather than spending a lot of time figuring out exactly what is happening with jQuery, I'm just switching it to use `.css` instead.

Tested by:
* Pointed local fuelux-site at local fuelux gh-pages and edited version of fuelux served up by local gh-pages to include this fix. Bug was no longer present.

Then, edited in Fuel UX repo and:
* Test by opening index page, viewing & scrolling repeater, resizing window, viewing & scrolling repeater. Repeater looked correct.
* Tested index dev page in Firefox (all 4 variations). Repeater looked correct.
* Tested index dev page in Chrome (all 4 variations). Repeater looked correct.
* Tested index dev page in IE 11 (all 4 variations) through BrowserStack. It had some “quirks” that were consistent with the “quirks” already present in IE 11.
* Tested index dev page in IE 10 (all 4 variations) through BrowserStack. It had some “quirks” that were consistent with the “quirks” already present in IE 10.
