### PR TITLE
separates out input-group-addon styles and updates index page html

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,26 @@
 						</div>
 					</section>
 
+					<section id="checkbox-add-on" class="x-panel x-panel-default">
+						<header class="hidden x-panel-heading">
+							<h3 class="panel-title">Checkbox within input-group-addon</h3>
+						</header>
+						<section class="x-panel-body">
+							<div class="input-group" id="inputwithcheckbox">
+								<input id="inputwithcheckboxInput" name="inputwithcheckboxInput" class=" form-control" placeholder="placeholder">
+								<label class="input-group-addon checkbox-custom" data-initialize="checkbox">
+									<input class="sr-only" type="checkbox" aria-label="..." id="inputwithcheckboxCheckbox" value="option1">
+								</label>
+							</div>
+							<div class="input-group" id="inputwithcheckbox">
+								<label class="input-group-addon checkbox-custom" data-initialize="checkbox">
+									<input class="sr-only" type="checkbox" aria-label="..." id="inputwithcheckboxCheckbox" value="option1">
+								</label>
+								<input id="inputwithcheckboxInput" name="inputwithcheckboxInput" class=" form-control" placeholder="placeholder">
+							</div><!-- /input-group -->
+						</section>
+					</section>
+
 					<section id="checkboxes-highlighting-inline">
 						<label class="checkbox-custom checkbox-inline highlight" data-initialize="checkbox" id="myCustomHighlightCheckbox5">
 							<input type="checkbox" class="sr-only">
@@ -312,23 +332,6 @@
 								</label>
 							</div>
 
-						</section>
-					</section>
-
-					<section id="checkbox-no-js-add-on" class="x-panel x-panel-default">
-						<header class="hidden x-panel-heading">
-							<h3 class="panel-title">Checkbox (no javascript) Checkbox inline within input-group-addon</h3>
-						</header>
-						<section class="x-panel-body">
-							<div class="input-group">
-								<span class="input-group-addon">
-									<span class="checkbox-inline">
-										<input type="checkbox" id="example-checkbox-addon" checked="checked" value="">
-										<label for="example-checkbox-addon"></label>
-									</span>
-								</span>
-								<input type="text" class="form-control" value="Checkbox within input add-on">
-							</div><!-- /input-group -->
 						</section>
 					</section>
 

--- a/less/checkbox.less
+++ b/less/checkbox.less
@@ -43,9 +43,21 @@
 		padding-top: 0;
 	}
 
-	.input-group-addon.checkbox-custom.checkbox-inline:before {
-		left: 11px;
-		top: 9px;
+
+	.input-group-addon.checkbox-custom {
+		margin-bottom: 0;
+		cursor: pointer;
+		padding-left: 24px;
+
+		input[type=checkbox]{
+			position: absolute;
+			margin-left: -24px;
+		}
+
+		&:before {
+			left: 11px;
+			top: 9px;
+		}
 	}
 
 	.checkbox-custom {


### PR DESCRIPTION
Chrome:
![image](https://cloud.githubusercontent.com/assets/8006971/11571974/fe17600a-99cc-11e5-93dc-6a796a2203ae.png)

IE10
![image](https://cloud.githubusercontent.com/assets/8006971/11571986/095b8e3c-99cd-11e5-81cc-bae0c4d0c6f5.png)

IE11
![image](https://cloud.githubusercontent.com/assets/8006971/11572000/17eb879a-99cd-11e5-8d09-2064d41c6e95.png)

Firefox
![image](https://cloud.githubusercontent.com/assets/8006971/11572010/245aa768-99cd-11e5-8c59-cb1837db3f98.png)


fixes #1644 

Addresses https://github.exacttarget.com/uxarchitecture/fuelux-site/issues/4