### PR TITLE
Placard contenteditable div support

### DIFF
--- a/index.html
+++ b/index.html
@@ -719,6 +719,34 @@
 							</div>
 						</div>
 					</div>
+
+					<br/>
+
+					<div class="placard" data-ellipsis="true" data-initialize="placard" id="myPlacard4">
+						<div class="placard-popup"></div>
+						<div class="placard-header">
+							<h5>Header</h5>
+						</div>
+						<div class="form-control placard-field" contenteditable="true"></div>
+						<div class="placard-footer">
+							<a class="placard-cancel" href="#">Cancel</a>
+							<button class="btn btn-primary btn-xs placard-accept" type="button">Save</button>
+						</div>
+					</div>
+
+					<div style="display: inline-block; padding: 10px;">
+						<div class="placard" data-initialize="placard" id="myPlacard5">
+							<div class="placard-popup"></div>
+							<div class="placard-header">
+								<h5>Header</h5>
+							</div>
+							<div class="form-control placard-field" contenteditable="true" data-textarea="true"></div>
+							<div class="placard-footer">
+								<a class="placard-cancel" href="#">Cancel</a>
+								<button class="btn btn-primary btn-xs placard-accept" type="button">Save</button>
+							</div>
+						</div>
+					</div>
 				</div>
 				<div class="btn-panel">
 					<button type="button" class="btn btn-default" id="btnPlacardEnable">enable</button>

--- a/js/placard.js
+++ b/js/placard.js
@@ -55,9 +55,10 @@
 			this.options.revertOnCancel = (this.$accept.length > 0);
 		}
 
-		this.isDiv = this.$field.is('div');
+		// Placard supports inputs, textareas, or contenteditable divs. These checks determine which is being used
+		this.isContentEditableDiv = this.$field.is('div');
 		this.isInput = this.$field.is('input');
-		this.divInTextareaMode = (this.isDiv && this.$field.attr('data-textarea') === 'true');
+		this.divInTextareaMode = (this.isContentEditableDiv && this.$field.attr('data-textarea') === 'true');
 
 		this.$field.on('focus.fu.placard', $.proxy(this.show, this));
 		this.$field.on('keydown.fu.placard', $.proxy(this.keyComplete, this));
@@ -114,7 +115,7 @@
 		},
 
 		keyComplete: function keyComplete(e) {
-			if (((this.isDiv && !this.divInTextareaMode) || this.isInput) && e.keyCode === 13) {
+			if (((this.isContentEditableDiv && !this.divInTextareaMode) || this.isInput) && e.keyCode === 13) {
 				this.complete('accepted');
 				this.$field.blur();
 			} else if (e.keyCode === 27) {
@@ -140,7 +141,7 @@
 		disable: function disable() {
 			this.$element.addClass('disabled');
 			this.$field.attr('disabled', 'disabled');
-			if (this.isDiv) {
+			if (this.isContentEditableDiv) {
 				this.$field.removeAttr('contenteditable');
 			}
 			this.hide();
@@ -150,7 +151,7 @@
 			var field, i, str;
 			if (this.options.applyEllipsis) {
 				field = this.$field.get(0);
-				if ((this.isDiv && !this.divInTextareaMode) || this.isInput) {
+				if ((this.isContentEditableDiv && !this.divInTextareaMode) || this.isInput) {
 					field.scrollLeft = 0;
 				} else {
 					field.scrollTop = 0;
@@ -175,7 +176,7 @@
 		enable: function enable() {
 			this.$element.removeClass('disabled');
 			this.$field.removeAttr('disabled');
-			if (this.isDiv) {
+			if (this.isContentEditableDiv) {
 				this.$field.attr('contenteditable', 'true');
 			}
 		},
@@ -189,7 +190,7 @@
 		getValue: function getValue() {
 			if (this.actualValue !== null) {
 				return this.actualValue;
-			} else if (this.isDiv) {
+			} else if (this.isContentEditableDiv) {
 				return this.$field.html();
 			} else {
 				return this.$field.val();
@@ -245,7 +246,7 @@
 				suppressEllipsis = !this.options.applyEllipsis;
 			}
 
-			if (this.isDiv) {
+			if (this.isContentEditableDiv) {
 				this.$field.empty().append(val);
 			} else {
 				this.$field.val(val);
@@ -262,7 +263,7 @@
 			if (_isShown(this)) { return; }
 			if (!_closeOtherPlacards()) { return; }
 
-			this.previousValue = (this.isDiv) ? this.$field.html() : this.$field.val();
+			this.previousValue = (this.isContentEditableDiv) ? this.$field.html() : this.$field.val();
 
 			if (this.actualValue !== null) {
 				this.setValue(this.actualValue, true);

--- a/js/placard.js
+++ b/js/placard.js
@@ -57,7 +57,7 @@
 
 		this.isDiv = this.$field.is('div');
 		this.isInput = this.$field.is('input');
-		this.textareaDivMode = (this.isDiv && this.$field.attr('data-textareamode') === 'true');
+		this.divInTextareaMode = (this.isDiv && this.$field.attr('data-textarea') === 'true');
 
 		this.$field.on('focus.fu.placard', $.proxy(this.show, this));
 		this.$field.on('keydown.fu.placard', $.proxy(this.keyComplete, this));
@@ -114,7 +114,7 @@
 		},
 
 		keyComplete: function keyComplete(e) {
-			if (((this.isDiv && !this.textareaDivMode) || this.isInput) && e.keyCode === 13) {
+			if (((this.isDiv && !this.divInTextareaMode) || this.isInput) && e.keyCode === 13) {
 				this.complete('accepted');
 				this.$field.blur();
 			} else if (e.keyCode === 27) {
@@ -150,10 +150,9 @@
 			var field, i, str;
 			if (this.options.applyEllipsis) {
 				field = this.$field.get(0);
-				if ((this.isDiv && !this.textareaDivMode) || this.isInput) {
+				if ((this.isDiv && !this.divInTextareaMode) || this.isInput) {
 					field.scrollLeft = 0;
 				} else {
-					//TODO: consider ellipsis for contenteditable divs
 					field.scrollTop = 0;
 					if (field.clientHeight < field.scrollHeight) {
 						this.actualValue = this.getValue();
@@ -191,7 +190,7 @@
 			if (this.actualValue !== null) {
 				return this.actualValue;
 			} else if (this.isDiv) {
-				return this.$field.html();	//TODO: should this be an object with contents and html?
+				return this.$field.html();
 			} else {
 				return this.$field.val();
 			}
@@ -266,7 +265,7 @@
 			this.previousValue = (this.isDiv) ? this.$field.html() : this.$field.val();
 
 			if (this.actualValue !== null) {
-				this.setValue(this.actualValue);
+				this.setValue(this.actualValue, true);
 				this.actualValue = null;
 			}
 

--- a/less/placard.less
+++ b/less/placard.less
@@ -7,14 +7,14 @@
 
 		&[data-ellipsis="true"] {
 			&.showing {
-				input.placard-field {
-					overflow: visible;
+				div.placard-field, input.placard-field {
+					overflow: auto;
 					text-overflow: clip;
 					white-space: normal;
 				}
 			}
 
-			input.placard-field {
+			div.placard-field, input.placard-field {
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
@@ -39,7 +39,7 @@
 				z-index: 1;
 			}
 
-			input.placard-field, textarea.placard-field {
+			div.placard-field, input.placard-field, textarea.placard-field {
 				background: @true-white;
 				border: 1px solid @gray80;
 				box-shadow: none;
@@ -48,7 +48,7 @@
 			}
 		}
 
-		input.placard-field, textarea.placard-field {
+		div.placard-field, input.placard-field, textarea.placard-field {
 			resize: none;
 
 			&[readonly] {
@@ -69,6 +69,11 @@
 				border: 1px solid @gray80;
 				box-shadow: none;
 			}
+		}
+
+		div.placard-field {
+			width: 168px;
+			overflow: auto;
 		}
 
 		&-cancel {

--- a/less/placard.less
+++ b/less/placard.less
@@ -24,6 +24,12 @@
 				}
 			}
 
+			div.placard-field[data-textarea] {
+				overflow: auto;
+				text-overflow: clip;
+				white-space: normal;
+			}
+
 			textarea.placard-field {
 				&[readonly] {
 					overflow: hidden;
@@ -74,6 +80,10 @@
 		div.placard-field {
 			width: 168px;
 			overflow: auto;
+
+			&[data-textarea] {
+				height: 54px;
+			}
 		}
 
 		&-cancel {

--- a/markup/placard-variations.txt
+++ b/markup/placard-variations.txt
@@ -1,6 +1,10 @@
 //Text area placard
 - replace input element classed '.placard-field' with the following:
-    '<textarea class="form-control placard-field" readonly="readonly"></textarea>'
+    '<textarea class="form-control placard-field"></textarea>'
+
+//Content-editable div placard
+- replace input element classed '.placard-field' with the following:
+    '<div class="form-control placard-field" contenteditable="true"></div>'
 
 //Glass styling
 - add the class 'glass' to the '.placard-field' element

--- a/test/markup/placard-markup.html
+++ b/test/markup/placard-markup.html
@@ -24,6 +24,16 @@
 		</div>
 	</div>
 
+	<div class="placard" data-ellipsis="true" id="placard3">
+		<div class="placard-popup"></div>
+		<div class="placard-header"><h5>Header</h5></div>
+		<div class="form-control placard-field" contenteditable="true"></div>
+		<div class="placard-footer">
+			<a class="placard-cancel" href="#">Cancel</a>
+			<button class="btn btn-primary btn-xs placard-accept" type="button">Save</button>
+		</div>
+	</div>
+
 </div>
 </body>
 </html>

--- a/test/placard-test.js
+++ b/test/placard-test.js
@@ -56,6 +56,23 @@ define(function(require){
 		$placard.remove();
 	});
 
+	test('should behave as expected - contenteditable div', function(){
+		var $placard = $(html).find('#placard3');
+
+		$placard.placard();
+		$placard.on('cancelled.fu.placard', function(e, helpers){
+			ok(1===1, 'default action event (cancel) triggered upon external click');
+		});
+		$('body').append($placard);
+
+		$placard.find('.placard-field').focus().focus();
+		equal($placard.hasClass('showing'), true, 'placard shows when appropriate');
+
+		$('body').click();
+		equal($placard.hasClass('showing'), false, 'placard hides when appropriate');
+		$placard.remove();
+	});
+
 	test('show/hide functions should behave as expected', function(){
 		var $placard = $(html).find('#placard1');
 		$placard.placard();


### PR DESCRIPTION
Fixes #1612 by allowing contenteditable divs to be used as the `.placard-field` element in placard. I've made it default to look and behave like a regular input, though you can add `data-textarea="true"` to the `.placard-field` element to make it instead look and behave like a textarea.

Additionally, I fixed a bug I noticed with ellipsis for textareas.

Documentation will need to be updated separately.