### PR TITLE
Repeater sub-controls and functions now acknowledge overall disabled state

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -244,7 +244,7 @@
 			}
 
 			var selectlist = '<div class="btn-group">' +
-				'<button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown" data-flip="auto" aria-expanded="false">' +
+				'<button type="button" class="btn btn-xs btn-default dropdown-toggle repeater-actions-button" data-toggle="dropdown" data-flip="auto" aria-expanded="false">' +
 				'<span class="caret"></span>' +
 				'</button>' +
 				'<ul class="dropdown-menu dropdown-menu-right" role="menu">' +
@@ -449,6 +449,16 @@
 				}
 				return options;
 			},
+			enabled: function (helpers) {
+				if (this.viewOptions.list_actions) {
+					if (!helpers.status) {
+						this.$canvas.find('.repeater-actions-button').attr('disabled', 'disabled');
+					} else {
+						this.$canvas.find('.repeater-actions-button').removeAttr('disabled');
+						toggleActionsHeaderButton.call(this);
+					}
+				}
+			},
 			initialize: function (helpers, callback) {
 				this.list_sortDirection = null;
 				this.list_sortProperty = null;
@@ -546,7 +556,7 @@
 	}
 
 	//ADDITIONAL METHODS
-	var areDifferentColumns = function areDifferentColumns (oldCols, newCols) {
+	function areDifferentColumns (oldCols, newCols) {
 		if (!newCols) {
 			return false;
 		}
@@ -567,7 +577,7 @@
 
 		}
 		return false;
-	};
+	}
 
 	function renderColumn ($row, rows, rowIndex, columns, columnIndex) {
 		var className = columns[columnIndex].className;
@@ -589,7 +599,7 @@
 		$row.append($col);
 
 		if (this.viewOptions.list_selectable === 'multi' && columns[columnIndex].property === '@_CHECKBOX_@') {
-			var checkBoxMarkup = '<label data-row="'+ rowIndex +'" class="checkbox-custom checkbox-inline body-checkbox">' +
+			var checkBoxMarkup = '<label data-row="'+ rowIndex +'" class="checkbox-custom checkbox-inline body-checkbox repeater-select-checkbox">' +
 				'<input class="sr-only" type="checkbox"></label>';
 
 			$col.html(checkBoxMarkup);
@@ -610,7 +620,7 @@
 		var chevron = '.glyphicon.rlc:first';
 		var chevUp = 'glyphicon-chevron-up';
 		var $div = $('<div class="repeater-list-heading"><span class="glyphicon rlc"></span></div>');
-		var checkBoxMarkup = '<div class="repeater-list-heading header-checkbox"><label class="checkbox-custom checkbox-inline">' +
+		var checkBoxMarkup = '<div class="repeater-list-heading header-checkbox"><label class="checkbox-custom checkbox-inline repeater-select-checkbox">' +
 			'<input class="sr-only" type="checkbox"></label><div class="clearfix"></div></div>';
 		var $header = $('<th></th>');
 		var self = this;
@@ -752,15 +762,8 @@
 						}
 						self.$element.trigger('selected.fu.repeaterList', $item);
 					}
-					var $selected = self.$canvas.find('.repeater-list-wrapper > table .selected');
-					var $actionsColumn = self.$element.find('.table-actions');
 
-					if ($selected.length > 0) {
-						$actionsColumn.find('thead .btn').removeAttr('disabled');
-					}
-					else {
-						$actionsColumn.find('thead .btn').attr('disabled', 'disabled');
-					}
+					toggleActionsHeaderButton.call(self);
 				}
 			});
 
@@ -912,7 +915,7 @@
 		}
 	}
 
-	function specialBrowserClass() {
+	function specialBrowserClass () {
 		var ua = window.navigator.userAgent;
 		var msie = ua.indexOf("MSIE ");
 		var firefox = ua.indexOf('Firefox');
@@ -923,6 +926,16 @@
 			return 'firefox';
 		} else {
 			return '';
+		}
+	}
+
+	function toggleActionsHeaderButton () {
+		var $selected = this.$canvas.find('.repeater-list-wrapper > table .selected');
+		var $actionsColumn = this.$element.find('.table-actions');
+		if ($selected.length > 0) {
+			$actionsColumn.find('thead .btn').removeAttr('disabled');
+		} else {
+			$actionsColumn.find('thead .btn').attr('disabled', 'disabled');
 		}
 	}
 

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -286,7 +286,7 @@
 
 			//row level actions click
 			this.$element.find('.table-actions tbody .action-item').on('click', function(e) {
-				if (self.$element.hasClass('disabled')) return;
+				if (self.isDisabled) return;
 
 				var actionName = $(this).data('action');
 				var row = $(this).data('row');
@@ -298,7 +298,7 @@
 			});
 			// bulk actions click
 			this.$element.find('.table-actions thead .action-item').on('click', function(e) {
-				if (self.$element.hasClass('disabled')) return;
+				if (self.isDisabled) return;
 
 				var actionName = $(this).data('action');
 				var selected = {
@@ -384,7 +384,7 @@
 				e.preventDefault();
 
 				if (!self.list_revertingCheckbox) {
-					if (self.$element.hasClass('disabled')) {
+					if (self.isDisabled) {
 						revertCheckbox($(e.currentTarget));
 					} else {
 						var row = $(this).attr('data-row');
@@ -396,7 +396,7 @@
 
 			this.$element.find('.frozen-thead-wrapper thead .checkbox-inline').on('change', function (e) {
 				if (!self.list_revertingCheckbox) {
-					if (self.$element.hasClass('disabled')) {
+					if (self.isDisabled) {
 						revertCheckbox($(e.currentTarget));
 					} else {
 						if ($(this).checkbox('isChecked')){
@@ -653,7 +653,7 @@
 		if (sortable) {
 			$both.addClass('sortable');
 			$div.on('click.fu.repeaterList', function () {
-				if (self.$element.hasClass('disabled')) return;
+				if (self.isDisabled) return;
 
 				self.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
 				if ($div.hasClass('sorted')) {
@@ -716,7 +716,7 @@
 			$row.data('item_data', rows[index]);
 
 			$row.on('click.fu.repeaterList', function () {
-				if (self.$element.hasClass('disabled')) return;
+				if (self.isDisabled) return;
 
 				var $item = $(this);
 				var index = $(this).index();

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -286,6 +286,8 @@
 
 			//row level actions click
 			this.$element.find('.table-actions tbody .action-item').on('click', function(e) {
+				if (self.$element.hasClass('disabled')) return;
+
 				var actionName = $(this).data('action');
 				var row = $(this).data('row');
 				var selected = {
@@ -296,6 +298,8 @@
 			});
 			// bulk actions click
 			this.$element.find('.table-actions thead .action-item').on('click', function(e) {
+				if (self.$element.hasClass('disabled')) return;
+
 				var actionName = $(this).data('action');
 				var selected = {
 					actionName: actionName,
@@ -378,21 +382,47 @@
 
 			this.$element.find('.table-frozen tbody .checkbox-inline').on('change', function(e) {
 				e.preventDefault();
-				var row = $(this).attr('data-row');
-				row = parseInt(row) + 1;
-				self.$element.find('.repeater-list-wrapper > table tbody tr:nth-child('+ row +')').click();
+
+				if (!self.list_revertingCheckbox) {
+					if (self.$element.hasClass('disabled')) {
+						revertCheckbox($(e.currentTarget));
+					} else {
+						var row = $(this).attr('data-row');
+						row = parseInt(row) + 1;
+						self.$element.find('.repeater-list-wrapper > table tbody tr:nth-child('+ row +')').click();
+					}
+				}
 			});
 
-			this.$element.find('.frozen-thead-wrapper thead .checkbox-inline').on('change', function () {
-				if ($(this).checkbox('isChecked')){
-					self.$element.find('.repeater-list-wrapper > table tbody tr:not(.selected)').click();
-					self.$element.trigger('selected.fu.repeaterList', $checkboxes);
-				}
-				else {
-					self.$element.find('.repeater-list-wrapper > table tbody tr.selected').click();
-					self.$element.trigger('deselected.fu.repeaterList', $checkboxes);
+			this.$element.find('.frozen-thead-wrapper thead .checkbox-inline').on('change', function (e) {
+				if (!self.list_revertingCheckbox) {
+					if (self.$element.hasClass('disabled')) {
+						revertCheckbox($(e.currentTarget));
+					} else {
+						if ($(this).checkbox('isChecked')){
+							self.$element.find('.repeater-list-wrapper > table tbody tr:not(.selected)').click();
+							self.$element.trigger('selected.fu.repeaterList', $checkboxes);
+						}
+						else {
+							self.$element.find('.repeater-list-wrapper > table tbody tr.selected').click();
+							self.$element.trigger('deselected.fu.repeaterList', $checkboxes);
+						}
+					}
 				}
 			});
+
+			function revertCheckbox ($checkboxLabel) {
+				self.list_revertingCheckbox = true;
+				var $input = $checkboxLabel.find('input');
+				if ($input.is(':checked')) {
+					$checkboxLabel.removeClass('checked');
+					$input.prop('checked', false);
+				} else {
+					$checkboxLabel.addClass('checked');
+					$input.prop('checked', true);
+				}
+				delete self.list_revertingCheckbox;
+			}
 		};
 
 		//ADDITIONAL DEFAULT OPTIONS
@@ -623,6 +653,8 @@
 		if (sortable) {
 			$both.addClass('sortable');
 			$div.on('click.fu.repeaterList', function () {
+				if (self.$element.hasClass('disabled')) return;
+
 				self.list_sortProperty = (typeof sortable === 'string') ? sortable : columns[index].property;
 				if ($div.hasClass('sorted')) {
 					if ($span.hasClass(chevUp)) {
@@ -684,6 +716,8 @@
 			$row.data('item_data', rows[index]);
 
 			$row.on('click.fu.repeaterList', function () {
+				if (self.$element.hasClass('disabled')) return;
+
 				var $item = $(this);
 				var index = $(this).index();
 				index = index + 1;

--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -411,16 +411,9 @@
 				}
 			});
 
-			function revertCheckbox ($checkboxLabel) {
+			function revertCheckbox ($checkbox) {
 				self.list_revertingCheckbox = true;
-				var $input = $checkboxLabel.find('input');
-				if ($input.is(':checked')) {
-					$checkboxLabel.removeClass('checked');
-					$input.prop('checked', false);
-				} else {
-					$checkboxLabel.addClass('checked');
-					$input.prop('checked', true);
-				}
+				$checkbox.checkbox('toggle');
 				delete self.list_revertingCheckbox;
 			}
 		};

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -170,6 +170,8 @@
 				if (selectable) {
 					$thumbnail.addClass('selectable');
 					$thumbnail.on('click', function () {
+						if (self.$element.hasClass('disabled')) return;
+
 						if (!$thumbnail.hasClass(selected)) {
 							if (selectable !== 'multi') {
 								self.$canvas.find('.repeater-thumbnail-cont .selectable.selected').each(function () {

--- a/js/repeater-thumbnail.js
+++ b/js/repeater-thumbnail.js
@@ -170,7 +170,7 @@
 				if (selectable) {
 					$thumbnail.addClass('selectable');
 					$thumbnail.on('click', function () {
-						if (self.$element.hasClass('disabled')) return;
+						if (self.isDisabled) return;
 
 						if (!$thumbnail.hasClass(selected)) {
 							if (selectable !== 'multi') {

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -615,16 +615,15 @@
 					}
 
 					self.$loader.hide().loader('pause');
+					self.enable();
+
 					self.$element.trigger('rendered.fu.repeater', {
 						data: data,
 						options: dataOptions,
 						renderOptions: options
 					});
-
 					//for maintaining support of 'loaded' event
 					self.$element.trigger('loaded.fu.repeater', dataOptions);
-
-					self.enable();
 				});
 			});
 		},

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -55,6 +55,7 @@
 
 		this.currentPage = 0;
 		this.currentView = null;
+		this.isDisabled = false;
 		this.infiniteScrollingCallback = function () {};
 		this.infiniteScrollingCont = null;
 		this.infiniteScrollingEnabled = false;
@@ -230,6 +231,7 @@
 			this.$prevBtn.attr(disabled, disabled);
 			this.$nextBtn.attr(disabled, disabled);
 
+			this.isDisabled = true;
 			this.$element.addClass('disabled');
 			this.$element.trigger('disabled.fu.repeater');
 		},
@@ -267,6 +269,7 @@
 				this.$pageSize.selectlist('disable');
 			}
 
+			this.isDisabled = false;
 			this.$element.removeClass('disabled');
 			this.$element.trigger('enabled.fu.repeater');
 		},
@@ -763,7 +766,7 @@
 			var val = $selected.val();
 
 			if (!this.syncingViewButtonState) {
-				if (this.$element.hasClass('disabled') || $selected.parents('label:first').hasClass('disabled')) {
+				if (this.isDisabled || $selected.parents('label:first').hasClass('disabled')) {
 					this.syncViewButtonState();
 				} else {
 					this.render({

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -221,6 +221,7 @@
 		disable: function() {
 			var disable = 'disable';
 			var disabled = 'disabled';
+			var viewTypeObj = $.fn.repeater.viewTypes[this.viewType] || {};
 
 			this.$search.search(disable);
 			this.$filters.selectlist(disable);
@@ -231,6 +232,12 @@
 			this.$prevBtn.attr(disabled, disabled);
 			this.$nextBtn.attr(disabled, disabled);
 
+			if (viewTypeObj.enabled) {
+				viewTypeObj.enabled.call(this, {
+					status: false
+				});
+			}
+
 			this.isDisabled = true;
 			this.$element.addClass('disabled');
 			this.$element.trigger('disabled.fu.repeater');
@@ -240,6 +247,7 @@
 			var disabled = 'disabled';
 			var enable = 'enable';
 			var pageEnd = 'page-end';
+			var viewTypeObj = $.fn.repeater.viewTypes[this.viewType] || {};
 
 			this.$search.search(enable);
 			this.$filters.selectlist(enable);
@@ -267,6 +275,12 @@
 			}
 			else {
 				this.$pageSize.selectlist('disable');
+			}
+
+			if (viewTypeObj.enabled) {
+				viewTypeObj.enabled.call(this, {
+					status: true
+				});
 			}
 
 			this.isDisabled = false;

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -66,6 +66,7 @@
 		this.resizeTimeout = {};
 		this.stamp = new Date().getTime() + (Math.floor(Math.random() * 100) + 1);
 		this.storedDataSourceOpts = null;
+		this.syncingViewButtonState = false;
 		this.viewOptions = {};
 		this.viewType = null;
 
@@ -222,7 +223,7 @@
 
 			this.$search.search(disable);
 			this.$filters.selectlist(disable);
-			this.$views.find('label').attr(disabled, disabled);
+			this.$views.find('label, input').addClass(disabled).attr(disabled, disabled);
 			this.$pageSize.selectlist(disable);
 			this.$primaryPaging.find('.combobox').combobox(disable);
 			this.$secondaryPaging.attr(disabled, disabled);
@@ -240,7 +241,7 @@
 
 			this.$search.search(enable);
 			this.$filters.selectlist(enable);
-			this.$views.find('label').removeAttr(disabled);
+			this.$views.find('label, input').removeClass(disabled).removeAttr(disabled);
 			this.$pageSize.selectlist('enable');
 			this.$primaryPaging.find('.combobox').combobox(enable);
 			this.$secondaryPaging.removeAttr(disabled);
@@ -580,6 +581,8 @@
 				}
 			}
 
+			this.syncViewButtonState();
+
 			options.preserve = (options.preserve !== undefined) ? options.preserve : !viewChanged;
 			this.clear(options);
 
@@ -758,10 +761,31 @@
 		viewChanged: function (e) {
 			var $selected = $(e.target);
 			var val = $selected.val();
-			this.render({
-				changeView: val,
-				pageIncrement: null
-			});
+
+			if (!this.syncingViewButtonState) {
+				if (this.$element.hasClass('disabled') || $selected.parents('label:first').hasClass('disabled')) {
+					this.syncViewButtonState();
+				} else {
+					this.render({
+						changeView: val,
+						pageIncrement: null
+					});
+				}
+			}
+		},
+
+		syncViewButtonState: function () {
+			var $itemToCheck = this.$views.find('input[value="' + this.currentView + '"]');
+
+			this.syncingViewButtonState = true;
+			this.$views.find('input').prop('checked', false);
+			this.$views.find('label.active').removeClass('active');
+
+			if ($itemToCheck.length > 0) {
+				$itemToCheck.prop('checked', true);
+				$itemToCheck.parents('label:first').addClass('active');
+			}
+			this.syncingViewButtonState = false;
 		}
 	};
 

--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -25,6 +25,44 @@
 
 .fuelux {
 	.repeater[data-viewtype="list"] {
+		&.disabled {	//overrides for disabled stuff
+			.repeater-canvas {
+				&.actions-enabled {
+					.repeater-list .actions-column-wrapper table.table-actions tr.selectable {
+						&:hover td, &.hovered td {
+							background: #fff;
+						}
+					}
+				}
+
+				.repeater-list {
+					.repeater-select-checkbox {
+						cursor: not-allowed;
+					}
+
+					.repeater-list-wrapper table thead tr th {
+						&.sortable, .repeater-list-heading.sortable{
+							background: @gray98;
+							cursor: auto;
+						}
+					}
+
+					.repeater-list-wrapper table tbody tr.selectable {
+						&:hover, &.hovered {
+							&.selected td {
+								background: #eee;
+							}
+
+							td {
+								background: #fff;
+								cursor: auto;
+							}
+						}
+					}
+				}
+			}
+		}
+
 		.repeater-canvas {
 			&.scrolling {
 				overflow: visible;

--- a/less/repeater-thumbnail.less
+++ b/less/repeater-thumbnail.less
@@ -1,5 +1,17 @@
 @import "fuelux-core.less";
 .fuelux {
+	.repeater.disabled {	//overrides for disabled stuff
+		.repeater-thumbnail.selectable {
+			&:hover {
+				background: #fff;
+				cursor: auto;
+			}
+
+			&.selected:hover {
+				background: @selected;
+			}
+		}
+	}
 
 	.repeater-thumbnail {
 		border: 1px solid @gray87;

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -314,6 +314,8 @@ define(function(require){
 			setTimeout(function(){
 				$repeater.repeater('disable');
 
+				$views.click();
+
 				equal($search.hasClass(disabled), true, 'repeater search disabled as expected');
 				equal($filters.hasClass(disabled), true, 'repeater filters disabled as expected');
 				equal($views.attr(disabled), disabled, 'repeater views disabled as expected');


### PR DESCRIPTION
Fixes #1534 by making sub-controls account for disabled state. The following items now don't work when the repeater is disabled:

- view switching via the `.repeater-views` radio buttons
- selecting items within repeater list
- filtering items within repeater list
- selecting items within repeater thumbnail

Additionally, I have fixed an issue where rendering a different view manually via the `render` method did not also change the selected view radio button :)