### PR TITLE
Tree lazy loading

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "qunit": "1.x",
     "requirejs-text": "2.x",
     "underscore": "1.x",
-    "blanket": "1.x"
+    "blanket": "1.x",
+    "require-handlebars-plugin": "~1.0.0"
   },
   "ignore": [
     "**/.*",

--- a/index.html
+++ b/index.html
@@ -33,13 +33,19 @@
 					underscore: 'bower_components/underscore/underscore',
 					bootstrap: 'bower_components/bootstrap/dist/js/bootstrap',
 					moment: 'bower_components/moment/min/moment-with-locales',
-					fuelux: 'js'
+					fuelux: 'js',
+					hbs: 'bower_components/require-handlebars-plugin/hbs',
+					fuelux_templates: 'templates/handlebars/fuelux',
+					bootstrap_templates: 'templates/handlebars/bootstrap'
 				},
 				shim: {
 					'bootstrap': {
 						deps: ['jquery'],
 						exports: 'bootstrap'
 					}
+				},
+				hbs: {
+					partialsUrl: 'templates/handlebars'
 				}
 			});
 		})();
@@ -2221,48 +2227,12 @@
 			<section id="tree">
 				<h2>Tree</h2>
 				<div class="thin-box">
+					<!-- Utilizes Handlebars templates (see index.js) -->
 					<h3>folders selectable (please note structure of treebranch)</h3>
-					<ul class="tree" id="myTree1" role="tree">
-						<li class="tree-branch hidden" data-template="treebranch" role="treeitem" aria-expanded="false">
-							<div class="tree-branch-header">
-								<button type="button" class="glyphicon icon-caret glyphicon-play"><span class="sr-only">Open</span>
-								</button>
-								<button type="button" class="tree-branch-name">
-									<span class="glyphicon icon-folder glyphicon-folder-close"></span>
-									<span class="tree-label"></span>
-								</button>
-							</div>
-							<ul class="tree-branch-children" role="group"></ul>
-							<div class="tree-loader" role="alert">Loading...</div>
-						</li>
-						<li class="tree-item hidden" data-template="treeitem" role="treeitem">
-							<button type="button" class="tree-item-name">
-								<span class="glyphicon icon-item fueluxicon-bullet"></span>
-								<span class="tree-label"></span>
-							</button>
-						</li>
-					</ul>
+					<div id="myTreeWrapper"></div>
 
 					<h3>only items selectable (please note structure of treebranch)</h3>
-					<ul class="tree" id="myTree2" role="tree">
-						<li class="tree-branch hidden" data-template="treebranch" role="treeitem" aria-expanded="false">
-							<div class="tree-branch-header">
-								<button type="button" class="tree-branch-name">
-									<span class="glyphicon icon-caret glyphicon-play"></span>
-									<span class="glyphicon icon-folder glyphicon-folder-close"></span>
-									<span class="tree-label"></span>
-								</button>
-							</div>
-							<ul class="tree-branch-children" role="group"></ul>
-							<div class="tree-loader" role="alert">Loading...</div>
-						</li>
-						<li class="tree-item hidden" data-template="treeitem" role="treeitem">
-							<button type="button" class="tree-item-name">
-								<span class="glyphicon icon-item fueluxicon-bullet"></span>
-								<span class="tree-label"></span>
-							</button>
-						</li>
-					</ul>
+					<div id="myTree2Wrapper"></div>
 
 				</div>
 				<div class="btn-panel">

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ define(function (require) {
 	require('fuelux/all');
 
 	var _ = require('underscore');
+	var hbs = require('hbs');
 
 
 	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -963,6 +964,10 @@ define(function (require) {
 	 TREE
 	 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
+	var tree = require('hbs!fuelux_templates/tree');
+	var $myTreeWrapper = $('#myTreeWrapper');
+	$myTreeWrapper.html(tree({id: 'myTree', folderSelect: true}));
+
 	var treeDataSource = function (parentData, callback) {
 		log('Opening branch data: ', parentData);
 
@@ -1026,13 +1031,21 @@ define(function (require) {
 						'attr': {
 							'id': 'item' + guid()
 						}
+					},
+					{
+						'name': 'Load More',
+						'type': 'overflow',
+						'attr': {
+							'layer': 'layer' + guid(),
+							'id': 'id' + guid()
+						}
 					}
 				]
 			});
 		}, 400);
 	};
 
-	$('#myTree1').tree({
+	$('#myTree').tree({
 		dataSource: treeDataSource,
 		cacheItems: true,
 		folderSelect: true,
@@ -1052,6 +1065,9 @@ define(function (require) {
 
 	// initialize
 	function myTreeInit () {
+		var $myTree2Wrapper = $('#myTree2Wrapper');
+		$myTree2Wrapper.html(tree({id: 'myTree2'}));
+
 		var callLimit = 200;
 		var callCount = 0;
 		$('#myTree2').tree({
@@ -1090,6 +1106,13 @@ define(function (require) {
 									'type': 'item',
 									'attr': {
 										'id': 'item' + guid()
+									}
+								},
+								{
+									'name': 'Load More',
+									'type': 'overflow',
+									'attr': {
+										'layer': 'layer' + guid()
 									}
 								}
 							]
@@ -1160,6 +1183,13 @@ define(function (require) {
 								'type': 'item',
 								'attr': {
 									'id': 'item' + guid()
+								}
+							},
+							{
+								'name': 'Load More Items',
+								'type': 'overflow',
+								'attr': {
+									'layer': 'layer' + guid()
 								}
 							}
 						]

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -255,10 +255,10 @@
 			this.$endDate.parent().attr('aria-hidden', 'true');
 
 			if (val === 'after') {
-				this.$endAfter.parent().removeClass('hide hidden'); // hide is deprecated
+				this.$endAfter.parent().removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 				this.$endAfter.parent().attr('aria-hidden', 'false');
 			} else if (val === 'date') {
-				this.$endDate.parent().removeClass('hide hidden');	// hide is deprecated
+				this.$endDate.parent().removeClass('hide hidden');	// jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 				this.$endDate.parent().attr('aria-hidden', 'false');
 			}
 		},
@@ -447,11 +447,11 @@
 				case 'daily':
 				case 'weekly':
 				case 'monthly':
-					this.$repeatIntervalPanel.removeClass('hide hidden'); // hide is deprecated
+					this.$repeatIntervalPanel.removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 					this.$repeatIntervalPanel.attr('aria-hidden', 'false');
 					break;
 				default:
-					this.$repeatIntervalPanel.addClass('hidden'); // hide is deprecated
+					this.$repeatIntervalPanel.addClass('hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 					this.$repeatIntervalPanel.attr('aria-hidden', 'true');
 					break;
 			}
@@ -461,7 +461,7 @@
 			this.$recurrencePanels.attr('aria-hidden', 'true');
 
 			// show panel for current selection
-			this.$element.find('.repeat-' + val).removeClass('hide hidden'); // hide is deprecated
+			this.$element.find('.repeat-' + val).removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 			this.$element.find('.repeat-' + val).attr('aria-hidden', 'false');
 
 			// the end selection should only be shown when
@@ -470,7 +470,7 @@
 				this.$end.addClass('hidden');
 				this.$end.attr('aria-hidden', 'true');
 			} else {
-				this.$end.removeClass('hide hidden'); // hide is deprecated
+				this.$end.removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 				this.$end.attr('aria-hidden', 'false');
 			}
 
@@ -511,7 +511,7 @@
 				item = 'hourly';
 			} else if (recur.FREQ === 'WEEKLY') {
 				item = 'weekly';
-				
+
 				if (recur.BYDAY) {
 					if (recur.BYDAY === 'MO,TU,WE,TH,FR') {
 						item = 'weekdays';
@@ -561,7 +561,7 @@
 					$repeatYearlyDay.find('input').addClass('checked').prop('checked', true);
 					$repeatYearlyDay.find('label.radio-custom').addClass('checked');
 					$repeatYearlyDay.find('.year-month-day-pos').selectlist('selectByValue', recur.BYSETPOS);
-					
+
 					if (recur.BYDAY) {
 						$repeatYearlyDay.find('.year-month-days').selectlist('selectByValue', recur.BYDAY);
 					}
@@ -581,7 +581,7 @@
 				this.$endSelect.selectlist('selectByValue', 'after');
 			} else if (recur.UNTIL) {
 				var untilSplit, untilDate;
-				
+
 				if (recur.UNTIL.length === 8) {
 					untilSplit = recur.UNTIL.split('');
 					untilSplit.splice(4, 0, '-');

--- a/js/tree.js
+++ b/js/tree.js
@@ -126,7 +126,7 @@
 			var $loader = $parent.find('.tree-loader:last');
 
 			if (isBackgroundProcess === false) {
-				$loader.removeClass('hide hidden'); // hide is deprecated
+				$loader.removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 			}
 
 
@@ -135,15 +135,15 @@
 					var $entity;
 
 					if (value.type === 'folder') {
-						$entity = self.$element.find('[data-template=treebranch]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treebranch]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 						$entity.data(value);
 						$entity.find('.tree-branch-name > .tree-label').html(value.text || value.name);
 					} else if (value.type === 'item') {
-						$entity = self.$element.find('[data-template=treeitem]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treeitem]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 						$entity.find('.tree-item-name > .tree-label').html(value.text || value.name);
 						$entity.data(value);
 					} else if (value.type === 'overflow') {
-						$entity = self.$element.find('[data-template=treeoverflow]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treeoverflow]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 						$entity.find('.tree-overflow-name > .tree-label').html(value.text || value.name);
 						$entity.data(value);
 					}
@@ -262,7 +262,7 @@
 			//take care of the styles
 			$branch.addClass('tree-open');
 			$branch.attr('aria-expanded', 'true');
-			$treeFolderContentFirstChild.removeClass('hide hidden'); // hide is deprecated
+			$treeFolderContentFirstChild.removeClass('hide hidden'); // jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 			$branch.find('> .tree-branch-header .icon-folder').eq(0)
 				.removeClass('glyphicon-folder-close')
 				.addClass('glyphicon-folder-open');
@@ -337,7 +337,7 @@
 			var closedReported = function closedReported(event, closed) {
 				reportedClosed.push(closed);
 
-				// hide is deprecated
+				// jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 				if (self.$element.find(".tree-branch.tree-open:not('.hidden, .hide')").length === 0) {
 					self.$element.trigger('closedAll.fu.tree', {
 						tree: self.$element,

--- a/js/tree.js
+++ b/js/tree.js
@@ -135,15 +135,15 @@
 					var $entity;
 
 					if (value.type === 'folder') {
-						$entity = self.$element.find('[data-template=treebranch]:eq(0)').clone().removeClass('hide hidden').removeData('template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treebranch]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
 						$entity.data(value);
 						$entity.find('.tree-branch-name > .tree-label').html(value.text || value.name);
 					} else if (value.type === 'item') {
-						$entity = self.$element.find('[data-template=treeitem]:eq(0)').clone().removeClass('hide hidden').removeData('template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treeitem]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
 						$entity.find('.tree-item-name > .tree-label').html(value.text || value.name);
 						$entity.data(value);
 					} else if (value.type === 'overflow') {
-						$entity = self.$element.find('[data-template=treeoverflow]:eq(0)').clone().removeClass('hide hidden').removeData('template'); // hide is deprecated
+						$entity = self.$element.find('[data-template=treeoverflow]:eq(0)').clone().removeClass('hide hidden').removeData('template').removeAttr('data-template'); // hide is deprecated
 						$entity.find('.tree-overflow-name > .tree-label').html(value.text || value.name);
 						$entity.data(value);
 					}

--- a/less/tree.less
+++ b/less/tree.less
@@ -32,8 +32,13 @@
 		}
 
 		.tree-loader {
-			// make even with tree-branch-children
-			margin-left: 45px;
+			// make even with tree-branch-children text
+			margin-left: 65px;
+		}
+
+		// The loader at the root level has different wrapping/nesting/spacing
+		> .tree-loader {
+			margin-left: 50px;
 		}
 
 		.tree-open > .tree-branch-header .glyphicon-play {
@@ -97,21 +102,26 @@
 
 		}
 
-		.tree-item {
+		.tree-item, .tree-overflow {
 			white-space: nowrap;
 			position: relative;
 			cursor: pointer;
 			border-radius: 6px;
 			margin-left: 26px;
 
-			.tree-item-name {
+			.tree-item-name, .tree-overflow-name {
 				white-space: nowrap;
 				border-radius: 6px;
 				background-color: transparent;
 				border: 0;
 			}
 
-			.tree-item-name:hover {
+			.tree-overflow-name .tree-label {
+				margin-left: 15px;
+				color: @link-color;
+			}
+
+			.tree-item-name:hover, .tree-overflow-name:hover {
 				color: @tree-hover-text;
 			}
 

--- a/markup/tree.html
+++ b/markup/tree.html
@@ -20,6 +20,13 @@
 			<span class="tree-label"></span>
 		</button>
 	</li>
+	<li class="tree-overflow hidden" data-template="treeoverflow" role="treeitem">
+		<button type="button" class="tree-overflow-name">
+			<span class="glyphicon"></span>
+			<span class="tree-label"></span>
+		</button>
+	</li>
+	<div class="tree-loader hidden" role="alert">Loading...</div>
 </ul>
 </body>
 </html>

--- a/templates/handlebars/fuelux/tree.hbs
+++ b/templates/handlebars/fuelux/tree.hbs
@@ -9,7 +9,8 @@
 			</button>
 		</div>
 		<ul class="tree-branch-children" role="group"></ul>
-		<div class="tree-loader" role="alert">Loading...</div>
+		<!-- this loader shows on nested folders and when overflow is triggered -->
+		{{#if loaderHTML }}{{loaderHTML}}{{else}}<div class="tree-loader hidden" role="alert">Loading...</div>{{/if}}
 	</li>
 	<li class="tree-item hidden" data-template="treeitem" role="treeitem">
 		<button type="button" class="tree-item-name">
@@ -17,4 +18,12 @@
 			<span class="tree-label"></span>
 		</button>
 	</li>
+	<li class="tree-overflow hidden" data-template="treeoverflow" role="treeitem">
+		<button type="button" class="tree-overflow-name">
+			<span class="glyphicon"></span>
+			<span class="tree-label"></span>
+		</button>
+	</li>
+	<!-- Loader shown at root level and when tree is loading -->
+	{{#if initialLoaderHTML}}{{initialLoaderHTML}}{{else}}{{#if loaderHTML }}{{loaderHTML}}{{else}}<div class="tree-loader hidden" role="alert">Loading...</div>{{/if}}{{/if}}
 </ul>

--- a/templates/handlebars/fuelux/tree.hbs
+++ b/templates/handlebars/fuelux/tree.hbs
@@ -25,5 +25,5 @@
 		</button>
 	</li>
 	<!-- Loader shown at root level and when tree is loading -->
-	{{#if initialLoaderHTML}}{{initialLoaderHTML}}{{else}}{{#if loaderHTML }}{{loaderHTML}}{{else}}<div class="tree-loader hidden" role="alert">Loading...</div>{{/if}}{{/if}}
+	{{#if initialLoaderHTML}}{{initialLoaderHTML}}{{else}}{{#if loaderHTML }}{{loaderHTML}}{{else}}<li class="tree-loader hidden" role="alert">Loading...</li>{{/if}}{{/if}}
 </ul>

--- a/test/markup/tree-markup.html
+++ b/test/markup/tree-markup.html
@@ -26,6 +26,13 @@
 					<span class="tree-label">Example Item</span>
 				</button>
 			</li>
+			<li class="tree-overflow hidden" data-template="treeoverflow" role="treeitem">
+				<button type="button" class="tree-overflow-name">
+					<span class="glyphicon"></span>
+					<span class="tree-label"></span>
+				</button>
+			</li>
+			<div class="tree-loader hidden" role="alert">Loading...</div>
 		</ul>
 
 		<ul id="MyTree2" class="tree" role="tree">
@@ -48,6 +55,13 @@
 					<span class="tree-label">Example Item</span>
 				</button>
 			</li>
+			<li class="tree-overflow hidden" data-template="treeoverflow" role="treeitem">
+				<button type="button" class="tree-overflow-name">
+					<span class="glyphicon"></span>
+					<span class="tree-label"></span>
+				</button>
+			</li>
+			<div class="tree-loader hidden" role="alert">Loading...</div>
 		</ul>
 
 	</div>
@@ -77,6 +91,13 @@
 					<span class="tree-label">Example Item</span>
 				</button>
 			</li>
+			<li class="tree-overflow hidden" data-template="treeoverflow" role="treeitem">
+				<button type="button" class="tree-overflow-name">
+					<span class="glyphicon"></span>
+					<span class="tree-label"></span>
+				</button>
+			</li>
+			<div class="tree-loader hidden" role="alert">Loading...</div>
 		</ul>
 
 	</div>

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -102,6 +102,13 @@ define(function (require) {
 							attr: {
 								id: 'item4'
 							}
+						},
+						{
+							name: 'Load More',
+							type: 'overflow',
+							attr: {
+								id: 'overflow1'
+							}
 						}
 					]
 				});
@@ -123,6 +130,11 @@ define(function (require) {
 
 		}
 	});
+
+	var NUM_CHILDREN = 9;
+	var NUM_FOLDERS = 4;
+	var NUM_ITEMS = 4;
+	var NUM_OVERFLOWS = 1;
 
 	test("should be defined on jquery object", function () {
 		ok($().tree, 'tree method is defined');
@@ -167,8 +179,9 @@ define(function (require) {
 			dataSource: this.dataSource
 		});
 
-		equal($tree.find('.tree-branch').length, 5, 'Initial set of folders have been added');
-		equal($tree.find('.tree-item').length, 5, 'Initial set of items have been added');
+		equal($tree.find('.tree-branch:not([data-template])').length, NUM_FOLDERS, 'Initial set of folders have been added');
+		equal($tree.find('.tree-item:not([data-template])').length, NUM_ITEMS, 'Initial set of items have been added');
+		equal($tree.find('.tree-overflow:not([data-template])').length, NUM_OVERFLOWS, 'Initial overflow has been added');
 	});
 
 	test("Folder should populate when opened", function () {
@@ -181,7 +194,7 @@ define(function (require) {
 
 		$selNode = $tree.find('.tree-branch:eq(1)');
 		$tree.tree('discloseFolder', $selNode.find('.tree-branch-name'));
-		equal($selNode.find('.tree-branch-children > li').length, 8, 'Folder has been populated with items/sub-folders');
+		equal($selNode.find('.tree-branch-children > li').length, NUM_CHILDREN, 'Folder has been populated with items/sub-folders');
 
 		$tree = $(html).find('#MyTreeSelectableFolder');
 
@@ -192,7 +205,7 @@ define(function (require) {
 
 		$selNode = $tree.find('.tree-branch:eq(1)');
 		$tree.tree('discloseFolder', $selNode.find('.tree-branch-header'));
-		equal($selNode.find('.tree-branch-children > li').length, 8, 'Folder has been populated with sub-folders and items');
+		equal($selNode.find('.tree-branch-children > li').length, NUM_CHILDREN, 'Folder has been populated with sub-folders and items');
 	});
 
 	test("getValue alias should function", function() {
@@ -244,6 +257,27 @@ define(function (require) {
 
 		$tree.find('.tree-item:eq(2)').click();
 		equal($tree.tree('selectedItems').length, 1, 'Return single selected item (folder previously selected, 3rd click selection)');
+
+	});
+
+	test("Overflow click works as designed", function () {
+		var $tree = $(html).find('#MyTree');
+
+		$tree.tree({
+			dataSource: this.dataSource
+		});
+
+		var $tree = $(html).find('#MyTree');
+
+		$tree.tree({
+			dataSource: this.dataSource
+		});
+
+		equal($tree.find('> li:not([data-template])').length, NUM_CHILDREN, 'Initial set of folders (' + NUM_CHILDREN + ' children) have been added');
+		$tree.find('.tree-overflow:eq(0)').click();
+		//Once overflow is clicked, all original contents is loaded again, and original overflow is actually REMOVED from tree contents.
+		var NUM_AFTER_OVERFLOW_CLICK = (NUM_CHILDREN * 2) - 1;
+		equal($tree.find('> li:not([data-template])').length, NUM_AFTER_OVERFLOW_CLICK, 'Overflow contents (now ' + NUM_AFTER_OVERFLOW_CLICK + ' children) have loaded');
 
 	});
 
@@ -388,7 +422,7 @@ define(function (require) {
 
 		// open folder
 		$tree.tree('discloseFolder', $folderToRefresh.find('.tree-branch-name'));
-		equal($folderToRefresh.find('.tree-branch-children > li').length, 8, 'Folder has been populated with items/sub-folders');
+		equal($folderToRefresh.find('.tree-branch-children > li').length, NUM_CHILDREN, 'Folder has been populated with items/sub-folders');
 		initialLoadedFolderId = $folderToRefresh.find(selector).attr('id');
 
 		// refresh and see if it's the same ID

--- a/test/tree-test.js
+++ b/test/tree-test.js
@@ -267,12 +267,6 @@ define(function (require) {
 			dataSource: this.dataSource
 		});
 
-		var $tree = $(html).find('#MyTree');
-
-		$tree.tree({
-			dataSource: this.dataSource
-		});
-
 		equal($tree.find('> li:not([data-template])').length, NUM_CHILDREN, 'Initial set of folders (' + NUM_CHILDREN + ' children) have been added');
 		$tree.find('.tree-overflow:eq(0)').click();
 		//Once overflow is clicked, all original contents is loaded again, and original overflow is actually REMOVED from tree contents.


### PR DESCRIPTION
closes #1708

Adds third leaf type to tree, `overflow`, that displays as a link wherever it appears in the tree, with whatever name the user provides as the link text. When clicked, behaves similar to clicking on a folder, except that it also passes its data attributes back to the datasource to allow the datasource to respond appropriately. Whatever is returned by the datasource is appended to the parent branch of the clicked overflow. Overflow is removed when it is clicked.

Incorporated this into the tree's handlebars template.

When adding tests I tried to filter by which items no longer had `data-template` and discovered that this attribute wasn't actually being removed (it seemed from the intent of the code that it should have been). I modified the tree code to remove this (it now runs `removeAttr("data-template")` after `removeData("template")` since it could feasibly cause further problems for others if they happen to call $() on a tree leaf (which would re-add the data back into jQuery's internal data store). This allowed for more fine-grained testing as well as potentially avoiding future bugs.

![tree-overflow](https://cloud.githubusercontent.com/assets/8006971/13180841/25c0ccaa-d6f8-11e5-8691-d68059cacaf7.gif)
