### PR TITLE
Adds ability to cancel repeater search

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -76,7 +76,8 @@
 		this.$pageSize.selectlist();
 		this.$primaryPaging.find('.combobox').combobox();
 		this.$search.search({
-			searchOnKeyPress: this.options.searchOnKeyPress
+			searchOnKeyPress: this.options.searchOnKeyPress,
+			allowCancel: true
 		});
 
 		this.$filters.on('changed.fu.selectlist', function (e, value) {
@@ -105,6 +106,10 @@
 				pageIncrement: null
 			});
 		});
+		this.$search.on('canceled.fu.search', function (e, value) {
+			self.$element.trigger('canceled.fu.repeater', value);
+		});
+
 		this.$secondaryPaging.on('blur.fu.repeater', function (e) {
 			self.pageInputChange(self.$secondaryPaging.val());
 		});
@@ -633,11 +638,13 @@
 					self.$loader.hide().loader('pause');
 					self.enable();
 
+					self.$search.trigger('rendered.fu.repeater');
 					self.$element.trigger('rendered.fu.repeater', {
 						data: data,
 						options: dataOptions,
 						renderOptions: options
 					});
+
 					//for maintaining support of 'loaded' event
 					self.$element.trigger('loaded.fu.repeater', dataOptions);
 				});

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -77,7 +77,7 @@
 		this.$primaryPaging.find('.combobox').combobox();
 		this.$search.search({
 			searchOnKeyPress: this.options.searchOnKeyPress,
-			allowCancel: true
+			allowCancel: this.options.allowCancel
 		});
 
 		this.$filters.on('changed.fu.selectlist', function (e, value) {
@@ -108,6 +108,10 @@
 		});
 		this.$search.on('canceled.fu.search', function (e, value) {
 			self.$element.trigger('canceled.fu.repeater', value);
+			self.render({
+				clearInfinite: true,
+				pageIncrement: null
+			});
 		});
 
 		this.$secondaryPaging.on('blur.fu.repeater', function (e) {
@@ -278,8 +282,7 @@
 			//if there are no items
 			if (parseInt(this.$count.html()) !== 0) {
 				this.$pageSize.selectlist('enable');
-			}
-			else {
+			} else {
 				this.$pageSize.selectlist('disable');
 			}
 
@@ -845,7 +848,8 @@
 		dropPagingCap: 10,
 		staticHeight: -1,	//normally true or false. -1 means it will look for data-staticheight on the element
 		views: null,		//can be set to an object to configure multiple views of the same type,
-		searchOnKeyPress: false
+		searchOnKeyPress: false,
+		allowCancel: true
 	};
 
 	$.fn.repeater.viewTypes = {};

--- a/js/search.js
+++ b/js/search.js
@@ -47,7 +47,7 @@
 		this.$button.on('click.fu.search', $.proxy(this.buttonclicked, this));
 		this.$input.on('keyup.fu.search', $.proxy(this.keypress, this));
 
-		if(this.$repeater.length > 0) {
+		if (this.$repeater.length > 0) {
 			this.$repeater.on('rendered.fu.repeater', $.proxy(this.clearPending, this));
 		}
 
@@ -86,7 +86,7 @@
 				this.$icon.removeClass('glyphicon-remove').addClass('glyphicon-search');
 			}
 
-			if(this.$element.hasClass('pending')) {
+			if (this.$element.hasClass('pending')) {
 				this.$element.trigger('canceled.fu.search');
 			}
 
@@ -105,8 +105,7 @@
 
 			if (val && val.length > 0) {
 				this.search(val);
-			}
-			else {
+			} else {
 				this.clear();
 			}
 		},
@@ -115,13 +114,9 @@
 			e.preventDefault();
 			if ($(e.currentTarget).is('.disabled, :disabled')) return;
 
-			if(this.$element.hasClass('pending')) {
+			if (this.$element.hasClass('pending') || this.$element.hasClass('searched')) {
 				this.clear();
-			}
-			else if(this.$element.hasClass('searched')) {
-				this.clear();
-			}
-			else {
+			} else {
 				this.action();
 			}
 		},
@@ -134,15 +129,12 @@
 			if (e.which === ENTER_KEY_CODE) {
 				e.preventDefault();
 				this.action();
-			}
-			else if(e.which === TAB_KEY_CODE) {
+			} else if (e.which === TAB_KEY_CODE) {
 				e.preventDefault();
-			}
-			else if(e.which === ESC_KEY_CODE) {
+			} else if (e.which === ESC_KEY_CODE) {
 				e.preventDefault();
 				this.clear();
-			}
-			else if(this.options.searchOnKeyPress) {
+			} else if (this.options.searchOnKeyPress) {
 				// search on other keypress
 				this.action();
 			}
@@ -152,7 +144,7 @@
 			this.$element.addClass('disabled');
 			this.$input.attr('disabled', 'disabled');
 
-			if(!this.options.allowCancel) {
+			if (!this.options.allowCancel) {
 				this.$button.addClass('disabled');
 			}
 		},

--- a/js/search.js
+++ b/js/search.js
@@ -45,7 +45,7 @@
 		this.$icon = this.$element.find('.glyphicon');
 
 		this.$button.on('click.fu.search', $.proxy(this.buttonclicked, this));
-		// this.$input.on('keyup.fu.search', $.proxy(this.keypress, this));
+		this.$input.on('keyup.fu.search', $.proxy(this.keypress, this));
 
 		if(this.$repeater.length > 0) {
 			this.$repeater.on('rendered.fu.repeater', $.proxy(this.clearPending, this));

--- a/js/search.js
+++ b/js/search.js
@@ -150,8 +150,9 @@
 
 		disable: function () {
 			this.$element.addClass('disabled');
+			this.$input.attr('disabled', 'disabled');
+
 			if(!this.options.allowCancel) {
-				this.$input.attr('disabled', 'disabled');
 				this.$button.addClass('disabled');
 			}
 		},

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -166,6 +166,36 @@ define(function(require){
 		});
 	});
 
+	test("should handle canceling search correctly", function () {
+		var count = -1;
+		var $repeater = $(this.$markup);
+		var $search = $repeater.find('.repeater-search');
+		$repeater.repeater({
+			dataSource: function(options, callback){
+				count++;
+				switch (count){
+					case 0:
+						equal(options.search, undefined, 'search value not passed to dataSource initially as expected');
+						callback({});
+						$search.find('input').val('something');
+						$search.trigger('searched.fu.repeater');
+						break;
+					case 1:
+						equal(options.search, 'something', 'correct search value passed to dataSource upon searching');
+						callback({});
+						$search.find('input').val('');
+						$search.trigger('canceled.fu.repeater');
+						break;
+					case 2:
+						equal(options.search, undefined, 'search value not passed to dataSource after canceling');
+						callback({});
+						break;
+				}
+			},
+			dropPagingCap: 3
+		});
+	});
+
 	test("should handle views correctly", function () {
 		var hasCalledDS = false;
 		var $repeater = $(this.$markup);


### PR DESCRIPTION
Fixes #1733 

- Added `pending` state to Search
- Added `allowsCancel` option to Search. Defaults to `FALSE`
- Repeater initializes Search with `allowsCancel: TRUE`
- On search, Search issues `searchChange` event to Repeater. Repeater disables Search, which with the `allowsCancel` option, does not disable the button. When Repeater is finished rendering, the `rendered` event is pushed to Search, removing the `pending` status and class. This returns the button to Clear functionality. If the button is pushed during `pending` status, the `canceled` event is pushed to Repeater. Repeater receives this event, and pushes it's own event out for the datasource to handle the cancelation of the XHR request or simply ignoring the results. Meanwhile, a render is performed and Search is cleared as normal.
- Attempted to write a unit test for this, but the existing unit tests don't seem to perform all 3 cases, so I'll need advising on how this was intended to work, and how I can fix both perhaps.
- Docs PR to follow after solution is merged


 
