### PR TITLE
Repeater combobox events

### DIFF
--- a/index.js
+++ b/index.js
@@ -675,6 +675,11 @@ define(function (require) {
 		initRepeater();
 	});
 
+	$('#myRepeater').on('pageChanged.fu.repeater', function (e, data) { 
+		console.log('pagechanged', e, data);
+	});
+
+
 	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	 REPEATER w/ actions
 	 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */

--- a/js/combobox.js
+++ b/js/combobox.js
@@ -83,12 +83,22 @@
 		},
 
 		doSelect: function ($item) {
+			
 			if (typeof $item[0] !== 'undefined') {
-				$item.addClass('selected');
+				// remove selection from old item, may result in remove and 
+				// re-addition of class if item is the same
+				this.$element.find('li.selected:first').removeClass('selected');
+
+				// add selection to new item
 				this.$selectedItem = $item;
+				this.$selectedItem.addClass('selected');
+
+				// update input
 				this.$input.val(this.$selectedItem.text().trim());
 			} else {
+				// this is a custom input, not in the menu
 				this.$selectedItem = null;
+				this.$element.find('li.selected:first').removeClass('selected');
 			}
 		},
 
@@ -120,7 +130,8 @@
 				}, this.$selectedItem.data());
 			} else {
 				data = {
-					text: this.$input.val().trim()
+					text: this.$input.val().trim(),
+					notFound: true
 				};
 			}
 
@@ -232,7 +243,6 @@
 				}
 
 				this.$inputGroupBtn.removeClass('open');
-				this.inputchanged(e);
 			} else if (e.which === ESC) {
 				e.preventDefault();
 				this.clearSelection();
@@ -256,8 +266,7 @@
 							$selected = this.$dropMenu.find('li:not(.hidden):last');
 						}
 					}
-					this.$dropMenu.find('li').removeClass('selected');
-					$selected.addClass('selected');
+					this.doSelect($selected);
 				}
 			}
 
@@ -270,10 +279,13 @@
 		},
 
 		inputchanged: function (e, extra) {
+			var val = $(e.target).val();
 			// skip processing for internally-generated synthetic event
 			// to avoid double processing
-			if (extra && extra.synthetic) return;
-			var val = $(e.target).val();
+			if (extra && extra.synthetic) {
+				this.selectByText(val);
+				return;
+			} 
 			this.selectByText(val);
 
 			// find match based on input

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -96,8 +96,7 @@
 		});
 		this.$prevBtn.on('click.fu.repeater', $.proxy(this.previous, this));
 		this.$primaryPaging.find('.combobox').on('changed.fu.combobox', function (evt, data) {
-			self.$element.trigger('pageChanged.fu.repeater', [data.text, data]);
-			self.pageInputChange(data.text);
+			self.pageInputChange(data.text, data);
 		});
 		this.$search.on('searched.fu.search cleared.fu.search', function (e, value) {
 			self.$element.trigger('searchChanged.fu.repeater', value);
@@ -473,13 +472,13 @@
 			});
 		},
 
-		pageInputChange: function (val) {
+		pageInputChange: function (val, data) {
 			var pageInc;
 			if (val !== this.lastPageInput) {
 				this.lastPageInput = val;
 				val = parseInt(val, 10) - 1;
 				pageInc = val - this.currentPage;
-				this.$element.trigger('pageChanged.fu.repeater', val);
+				this.$element.trigger('pageChanged.fu.repeater', [val, data]);
 				this.render({
 					pageIncrement: pageInc
 				});

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -472,13 +472,15 @@
 			});
 		},
 
-		pageInputChange: function (val, data) {
+		pageInputChange: function (val, dataFromCombobox) {
+			// dataFromCombobox is a proxy for data from combobox's changed event,
+			// if no combobox is present data will be undefined
 			var pageInc;
 			if (val !== this.lastPageInput) {
 				this.lastPageInput = val;
 				val = parseInt(val, 10) - 1;
 				pageInc = val - this.currentPage;
-				this.$element.trigger('pageChanged.fu.repeater', [val, data]);
+				this.$element.trigger('pageChanged.fu.repeater', {value: val, data: dataFromCombobox});
 				this.render({
 					pageIncrement: pageInc
 				});

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -480,7 +480,7 @@
 				this.lastPageInput = val;
 				val = parseInt(val, 10) - 1;
 				pageInc = val - this.currentPage;
-				this.$element.trigger('pageChanged.fu.repeater', {value: val, data: dataFromCombobox});
+				this.$element.trigger('pageChanged.fu.repeater', [val, dataFromCombobox]);
 				this.render({
 					pageIncrement: pageInc
 				});

--- a/test/combobox-test.js
+++ b/test/combobox-test.js
@@ -4,15 +4,20 @@
 
 define(function(require){
 	var $ = require('jquery');
-	var html = require('text!test/markup/combobox-markup.html!strip');
+	var originalHTML = require('text!test/markup/combobox-markup.html!strip');
 	/* FOR DEV TESTING - uncomment to test against index.html */
 	//html = require('text!index.html!strip');
-	html = $('<div>'+html+'</div>').find('#MyComboboxContainer');
+	var html = $('<div>'+originalHTML+'</div>').find('#MyComboboxContainer');
 
 	require('bootstrap');
 	require('fuelux/combobox');
 
-	module("Fuel UX Combobox");
+	module("Fuel UX Combobox", {
+		beforeEach: function () {
+			html = null;
+			html = $('<div>'+originalHTML+'</div>').find('#MyComboboxContainer');
+		}
+	});
 
 	test("should be defined on jquery object", function () {
 		ok($().combobox, 'combobox method is defined');
@@ -52,7 +57,7 @@ define(function(require){
 	test("should not autoselect when no default selection", function () {
 		var $combobox = $(html).find("#MyCombobox").combobox();
 		var item = $combobox.combobox('selectedItem');
-		var expectedItem = { text: '' };
+		var expectedItem = { notFound: true, text: '' };
 		deepEqual(item, expectedItem, 'no item selected');
 	});
 
@@ -141,13 +146,13 @@ define(function(require){
 			.trigger(ENTER_EVENT);
 	};
 
-	test("should respond to keypresses appropriately with filter and showOptionsOnKeypress off", function() {
+	test("should not select any menu items via keyboard navigation with filter off and showOptionsOnKeypress off", function() {
 		var $combobox = $(html).find("#MyCombobox").combobox();
 
 		userInteracts($combobox);
 
 		var item = $combobox.combobox('selectedItem');
-		var expectedItem = { text:'T' };
+		var expectedItem = { notFound: true, text:'T' };
 		deepEqual(item, expectedItem, 'Combobox was not triggered, filter not activated');
 	});
 
@@ -238,7 +243,7 @@ define(function(require){
 		equal(eventFireCount, 1, 'change event bubbled once');
 	});
 
-	test("should fire changed event - input changed", function () {
+	test("should fire changed event once when input is changed", function () {
 		var eventFireCount = 0;
 		var selectedText = '';
 


### PR DESCRIPTION
Fixes #1790 for @dkilgore 

`pageChanged.fu.repeater` should now only fire once. Repeater's `pageChanged` event will now return an array with a `[ [pageNumber], [dataObject] ]` shape.

**Additional help with paging and multiple `combobox` events**
If repeater only has two pages of data, the combobox will be present. If a `3` is entered into the combobox the data key will return the data from the combobox's `changed` event 

`{ notFound: true, text: '3'}`

The `3` is not present (since there are only two pages), therefore a `notFound` will be present in the data returned from the `combobox`. A 3 (or really a zero index 2, will still be passed into the repeater, but you can now check for the `notFound` key in order to revert to a valid page if you so choose.

Combobox was refactored, so that that `changed.fu.combobox` event did not fire twice when changed after typing and then using the enter key. Issues were also present that created multiple selected menu items due to previous item with `.selected` class were not being removed, but still determining what item selection by a query selector for `.selected:first`.

**Individual tests**
Individual tests for combobox were not being "taken down" and therefore tests were affecting each other and not isolated. It's a `noop/return` if you run `.combobox()` on a DOM element that has already been initialized.

_Please note: There are combobox tests that test events fire once, but there are no tests to check that `pagechanged.fu.repeater` runs once or any tests related to that event at all._