### PR TITLE
Remove spinbox mouse scrolling functionality

### DIFF
--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -51,8 +51,10 @@
 		this.$element.on('keydown.fu.spinbox', this.$input, $.proxy(this.keydown, this));
 		this.$element.on('keyup.fu.spinbox', this.$input, $.proxy(this.keyup, this));
 
-		this.bindMousewheelListeners();
-		this.mousewheelTimeout = {};
+		if (this.options.enableMouseWheelScroll) {
+			this.bindMousewheelListeners();
+			this.mousewheelTimeout = {};
+		}
 
 		if (this.options.hold) {
 			this.$element.on('mousedown.fu.spinbox', '.spinbox-up', $.proxy(function () {
@@ -436,7 +438,8 @@
 		units: [],
 		decimalMark: '.',
 		defaultUnit: '',
-		limitToStep: false
+		limitToStep: false,
+		enableMouseWheelScroll: false
 	};
 
 	$.fn.spinbox.Constructor = Spinbox;

--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -51,11 +51,6 @@
 		this.$element.on('keydown.fu.spinbox', this.$input, $.proxy(this.keydown, this));
 		this.$element.on('keyup.fu.spinbox', this.$input, $.proxy(this.keyup, this));
 
-		if (this.options.enableMouseWheelScroll) {
-			this.bindMousewheelListeners();
-			this.mousewheelTimeout = {};
-		}
-
 		if (this.options.hold) {
 			this.$element.on('mousedown.fu.spinbox', '.spinbox-up', $.proxy(function () {
 				this.startSpin(true);
@@ -358,47 +353,8 @@
 			if (keyCode === 38 || keyCode === 40) {
 				this.triggerChangedEvent();
 			}
-		},
-
-		bindMousewheelListeners: function bindMousewheelListeners() {
-			var inputEl = this.$input.get(0);
-			if (inputEl.addEventListener) {
-				//IE 9, Chrome, Safari, Opera
-				inputEl.addEventListener('mousewheel', $.proxy(this.mousewheelHandler, this), false);
-				// Firefox
-				inputEl.addEventListener('DOMMouseScroll', $.proxy(this.mousewheelHandler, this), false);
-			} else {
-				// IE <9
-				inputEl.attachEvent('onmousewheel', $.proxy(this.mousewheelHandler, this));
-			}
-		},
-
-		mousewheelHandler: function mousewheelHandler(event) {
-			if (!this.options.disabled) {
-				var e = window.event || event;// old IE support
-				var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
-				var self = this;
-
-				clearTimeout(this.mousewheelTimeout);
-				this.mousewheelTimeout = setTimeout(function () {
-					self.triggerChangedEvent();
-				}, 300);
-
-				if (delta < 0) {
-					this.step(true);
-				} else {
-					this.step(false);
-				}
-
-				if (e.preventDefault) {
-					e.preventDefault();
-				} else {
-					e.returnValue = false;
-				}
-
-				return false;
-			}
 		}
+
 	};
 
 
@@ -438,8 +394,7 @@
 		units: [],
 		decimalMark: '.',
 		defaultUnit: '',
-		limitToStep: false,
-		enableMouseWheelScroll: false
+		limitToStep: false
 	};
 
 	$.fn.spinbox.Constructor = Spinbox;


### PR DESCRIPTION
**USER EXPERIENCE CHANGE**
Spinbox no longer updates on mouse wheel scrolling. 

Re-enabling with the initialization option, `{enableMouseWheelScroll: true}`, was proposed, but rejected as a bad UX pattern.

Fixes #1814