### PR TITLE
Update repeater header checkbox to use correct markup

### DIFF
--- a/js/repeater-list.js
+++ b/js/repeater-list.js
@@ -404,6 +404,7 @@
 
 		$.fn.repeater.Constructor.prototype.list_frozenOptionsInitialize = function () {
 			var $checkboxes = this.$element.find('.frozen-column-wrapper .checkbox-inline');
+			var $headerCheckbox = this.$element.find('.header-checkbox .checkbox-custom');
 			var $everyTable = this.$element.find('.repeater-list table');
 			var self = this;
 
@@ -419,6 +420,7 @@
 				}
 			});
 
+			$headerCheckbox.checkbox();
 			$checkboxes.checkbox();
 
 			// Row checkboxes
@@ -687,8 +689,14 @@
 		var chevUp = 'glyphicon-chevron-up';
 		var $div = $('<div class="repeater-list-heading"><span class="glyphicon rlc"></span></div>');
 		var checkAllID = (this.$element.attr('id')+'_' || '') + 'checkall';
-		var checkBoxMarkup = '<div class="repeater-list-heading header-checkbox"><div class="checkbox checkbox-inline"><input type="checkbox" id="' + checkAllID + '">'+
-			'<label for="' + checkAllID + '"></label></div></div>';
+
+		var checkBoxMarkup = '<div class="repeater-list-heading header-checkbox">' +
+				'<label id="' + checkAllID + '" class="checkbox-custom checkbox-inline">' + 
+					'<input class="sr-only" type="checkbox" value="">' +
+					'<span class="checkbox-label">&nbsp;</span>' +
+				'</label>' +
+			'</div>';
+
 		var $header = $('<th></th>');
 		var self = this;
 		var $both, className, sortable, $span, $spans;

--- a/less/repeater-list.less
+++ b/less/repeater-list.less
@@ -1,5 +1,7 @@
 @import "fuelux-core.less";
 @mutli-select-enabled-width: 37px;
+
+// row checkboxes for selection and actions
 .selectable() {
 	&.selectable {
 		&:hover td, &.hovered td {
@@ -142,6 +144,11 @@
 							border-left: none;
 							.header-checkbox {
 								width: @mutli-select-enabled-width;
+								padding-left: 12px;
+
+								.checkbox-inline:before {
+									top: 0;
+								}
 							}
 						}
 


### PR DESCRIPTION
Hello, Fuel UX, old friend. It's been a while.

Partial fix to #251 in GHE's Fuel UX site. This corrects the markup generated by the repeater.

There shouldn't be any visual changes here. The main point was to wrap the `input` in the `label` to align with markup found in the [Fuel UX Checkbox](http://getfuelux.com/javascript.html#checkbox-examples-inline), so that we have the same starting point for checkboxes for the Lightning Theme.

![screen shot 2016-07-21 at 12 19 37 am](https://cloud.githubusercontent.com/assets/1290832/17011176/d8913b96-4ed8-11e6-9387-6c05785481f0.png)
