### PR TITLE
Provides data object to repeater render callbacks 

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -223,7 +223,11 @@
 		this.$loader.hide().loader('pause');
 		this.enable();
 
-		this.$search.trigger('rendered.fu.repeater');
+		this.$search.trigger('rendered.fu.repeater', {
+			data: data,
+			options: state.dataOptions,
+			renderOptions: state.options
+		});
 		this.$element.trigger('rendered.fu.repeater', {
 			data: data,
 			options: state.dataOptions,
@@ -786,7 +790,7 @@
 					addItem(this.$canvas, addAfter);
 				}
 
-				callback();
+				callback(data);
 			} else {
 				viewTypeObj.render.call(this, {
 					container: this.$canvas,

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -375,6 +375,51 @@ define(function repeaterTests (require) {
 		$repeater.repeater();
 	});
 
+	asyncTest('rendered.fu.repeater callback should receive correct data when called by renderItems function', function dataSourceCallbackTest () {
+		var $repeater = $(this.$markup);
+		var count = 0;
+		$repeater.on('rendered.fu.repeater', function(e, state) {
+			count++;
+			if (count === 2) {
+				start();
+			}
+
+			ok(state.data, 'data object exists');
+			equal(state.data.myVar, 'passalong', 'data returned from datasource was passed along');
+		});
+		$repeater.repeater({
+			views: {
+				'test1.view1': {
+					dataSource: function dataSource (options, callback) {
+						callback({myVar: 'passalong'});
+					}
+				}
+			}
+		});
+	});
+
+	asyncTest('custom view\'s render function should receive correct data when called by renderItems function', function dataSourceCallbackTest () {
+		var $repeater = $(this.$markup);
+
+		$.fn.repeater.viewTypes.test1 = {
+			render: function(state, callback) {
+				start();
+				ok(state.data, 'data was passed to custom viewtype callback');
+				equal(state.data.myVar, 'passalong', 'data returned from datasource was passed along to custom viewtype callback');
+				callback(state.data);
+			}
+		};
+		$repeater.repeater({
+			views: {
+				'test1.view1': {
+					dataSource: function dataSource (options, callback) {
+						callback({myVar: 'passalong'});
+					}
+				}
+			}
+		});
+	});
+
 	asyncTest('should destroy control', function destroy () {
 		var $repeater = $(this.$markup);
 


### PR DESCRIPTION
When repeater completes rendering a callback is called, which in turn triggers the `rendered.fu.repeater` function. This callback needs to receive the data provided by the dataSource so that it can pass it along through the trigger.

I noticed when writing the unit tests that the search object was having the same event triggered on it, but, was not receiving any data. I am now passing along the data for consistency sake (and so that tests would pass since they were expecting it).

fixes #1867 

To test:
- [x] pull changes
- [x] reset to `	17dbe60`
- [x] run unit tests `grunt test` (they should fail)
- [x] reset to `6894504`
- [x] run unit tests `grunt test` (they should now pass)
- [x] runt `grunt servefast`
- [x] open http://localhost:8000/ and interact with repeaters (paging, etc) and make sure they still work.
- [ ] review/comment on code

 

