### PR TITLE
(GH1887) adds ability to accomodate secondary text in template for wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -2188,6 +2188,9 @@
 
 			<section id="wizard">
 				<h2>Wizard</h2>
+				<div class="thin-box" id="myWizard1Wrapper">
+
+				</div>
 				<div class="thin-box">
 					<div class="wizard" data-initialize="wizard" id="myWizard">
 						<div class="steps-container">

--- a/index.js
+++ b/index.js
@@ -1419,6 +1419,71 @@ define(function (require) {
 		log(item);
 	});
 
+	var wizardStepsData = {
+		steps: [
+			{
+				step: 1,
+				stepBadge: 1,
+				stepLabel: 'Campaign',
+				secondaryText: 'This is secondary',
+				styles: 'alert',
+				active: true,
+				title: 'Setup Campaign',
+				content:'<p>Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon azuki bean garlic. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>' +
+						'<p>Turnip greens yarrow ricebean rutabaga endive cauliflower sea lettuce kohlrabi amaranth water spinach avocado daikon napa cabbage asparagus winter purslane kale. Celery potato scallion desert raisin horseradish spinach carrot soko. Lotus root water spinach fennel kombu maize bamboo shoot green bean swiss chard seakale pumpkin onion chickpea gram corn pea. Brussels sprout coriander water chestnut gourd swiss chard wakame kohlrabi beetroot carrot watercress. Corn amaranth salsify bunya nuts nori azuki bean chickweed potato bell pepper artichoke. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>' +
+						'<p>Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot courgette tatsoi pea sprouts fava bean collard greens dandelion okra wakame tomato. Dandelion cucumber earthnut pea peanut soko zucchini. </p>'
+			},
+			{
+				step: 2,
+				stepBadge: 2,
+				stepLabel: 'Recipients',
+				secondaryText: 'This is secondary',
+				styles: 'bg-info alert alert-info',
+				title: 'Choose Recipients',
+				content:'<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>' +
+						'<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach. </p>' +
+						'<p>Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean. Dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens. </p>'
+			},
+			{
+				step: 3,
+				stepBadge: 3,
+				stepLabel: 'Template',
+				secondaryText: 'This is secondary',
+				styles: 'bg-danger alert alert-danger',
+				title: 'Design Template',
+				content:'<p>Nori grape silver beet broccoli kombu beet greens fava bean potato quandong celery. Bunya nuts black-eyed pea prairie turnip leek lentil turnip greens parsnip. Sea lettuce lettuce water chestnut eggplant winter purslane fennel azuki bean earthnut pea sierra leone bologi leek soko chicory celtuce parsley jÃ­cama salsify. </p>' +
+						'<p>Celery quandong swiss chard chicory earthnut pea potato. Salsify taro catsear garlic gram celery bitterleaf wattle seed collard greens nori. Grape wattle seed kombu beetroot horseradish carrot squash brussels sprout chard. </p>' +
+						'<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo kakadu plum komatsuna black-eyed pea green bean zucchini gourd winter purslane silver beet rock melon radish asparagus spinach. </p>'
+			},
+			{
+				step: 4,
+				stepBadge: 4,
+				stepLabel: 'Preview',
+				secondaryText: 'This is secondary',
+				styles: 'bg-warning alert alert-warning',
+				title: 'Preview Message',
+				content:'<p>Beetroot water spinach okra water chestnut ricebean pea catsear courgette summer purslane. Water spinach arugula pea tatsoi aubergine spring onion bush tomato kale radicchio turnip chicory salsify pea sprouts fava bean. Dandelion zucchini burdock yarrow chickpea dandelion sorrel courgette turnip greens tigernut soybean radish artichoke wattle seed endive groundnut broccoli arugula. Beetroot water spinach okra water chestnut ricebean pea catsear courgette.</p>' +
+						'<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut. Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic.</p>' +
+						'<p>Ja­cama garlic courgette coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush tomato. </p>'
+			},
+			{
+				step: 5,
+				stepBadge: 5,
+				stepLabel: 'Send',
+				secondaryText: 'This is secondary',
+				styles: 'bg-success alert alert-success',
+				title: 'Send Message',
+				content:'<p>Soko radicchio bunya nuts gram dulse silver beet parsnip napa cabbage lotus root sea lettuce brussels sprout cabbage. Catsear cauliflower garbanzo yarrow salsify chicory garlic bell pepper napa cabbage lettuce tomato kale arugula melon sierra leone bologi rutabaga tigernut.</p>' +
+						'<p>Sea lettuce gumbo grape kale kombu cauliflower salsify kohlrabi okra sea lettuce broccoli celery lotus root carrot winter purslane turnip greens garlic. JÃ­cama garlic courgette coriander radicchio plantain scallion cauliflower fava bean desert raisin spring onion chicory bunya nuts. Sea lettuce water spinach gram fava bean leek dandelion silver beet eggplant bush tomato. </p>' +
+						'<p>Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jÃ­cama green bean celtuce collard greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd.  </p>'
+			}
+		]
+	}
+
+			var wizard = require('hbs!fuelux_templates/wizard');
+			var $myWizard1Wrapper = $('#myWizard1Wrapper');
+			$myWizard1Wrapper.html(wizard(wizardStepsData));
+
 
 	$('#btnWizardAddSteps').on('click', function () {
 		$('#myWizard').wizard('addSteps', 2, [{

--- a/less/wizard.less
+++ b/less/wizard.less
@@ -57,6 +57,20 @@
 				font-size: 16px;
 				cursor: not-allowed;
 
+				> .has-secondary-text {
+					display: inline;
+
+					> h4 {
+						display: inline;
+						font-size: 16px;
+						font-weight: normal;
+					}
+
+					> small {
+						display: none;
+					}
+				}
+
 				.chevron {
 					border: 24px solid transparent;
 					border-left: 14px solid @navbar-border;

--- a/templates/handlebars/fuelux/wizard.hbs
+++ b/templates/handlebars/fuelux/wizard.hbs
@@ -2,7 +2,7 @@
 	<div class="steps-container">
 		<ul class="steps">
 			{{#each steps}}
-				<li data-step="{{step}}" class="{{#if active}}active{{/if}}{{#if complete}}complete{{/if}}"><span class="badge">{{stepBadge}}</span>{{stepLabel}}<span class="chevron"></span></li>
+				<li data-step="{{step}}" class="{{#if active}}active{{/if}}{{#if complete}}complete{{/if}}"><span class="badge">{{stepBadge}}</span>{{#if secondaryText}}<div class="has-secondary-text"><h4>{{/if}}{{stepLabel}}{{#if secondaryText}}</h4><small>{{secondaryText}}</small></div>{{/if}}<span class="chevron"></span></li>
 			{{/each}}
 		</ul>
 	</div>


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/8006971/19662484/af3cbebe-9a05-11e6-8a81-60b96d9a20d0.png)

After:
![image](https://cloud.githubusercontent.com/assets/8006971/19662647/6549125c-9a06-11e6-9b14-36d45df4c293.png)

To test:

- [x] Pull branch
- [x] `npm install && grunt install`
- [x] `grunt servefast`
- [x] http://localhost:8000/#wizard
- [x] Compare first and second wizards, should be identical