### PR TITLE
Datepicker w/ Moment parseDate parsing strings results in good date object not `Invalid Date`

### DIFF
--- a/grunt/tasks/test.js
+++ b/grunt/tasks/test.js
@@ -18,7 +18,7 @@ module.exports = function test (grunt) {
 		['connect:testServer', 'jshint', 'saucelabs-qunit:defaultBrowsers']);
 
 	grunt.registerTask('travisci', 'Tests to run when in Travis CI environment',
-		['browserify:commonjs', 'test', 'dist', 'qunit:dist']);
+		['browserify:commonjs', 'dist', 'test', 'qunit:dist']);
 
 	// if you've already accidentally added your files for commit, this will at least unstage them. If you haven't, this will wipe them out.
 	grunt.registerTask('resetdist', 'resets changes to dist to keep them from being checked in', function resetdist () {

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -395,13 +395,13 @@
 						return (true === md.isValid()) ? md.toDate() : BAD_DATE;
 					};
 
-					tryMomentParseAll = function (d, parseFunc1, parseFunc2) {
-						var pd = parseFunc1(d);
+					tryMomentParseAll = function (rawDateString, parseFunc1, parseFunc2) {
+						var pd = parseFunc1(rawDateString);
 						if (!self.isInvalidDate(pd)) {
 							return pd;
 						}
 
-						pd = parseFunc2(pd);
+						pd = parseFunc2(rawDateString);
 						if (!self.isInvalidDate(pd)) {
 							return pd;
 						}

--- a/test/datepicker-moment-test.js
+++ b/test/datepicker-moment-test.js
@@ -129,12 +129,24 @@ define( function ( require ) {
 			assert.equal( date1, date2, "getValue alias matches getDate" );
 		} );
 
-		QUnit.test( "should set new date using setDate method", function( assert ) {
+		QUnit.test( "should set new date using setDate method passing a Date object", function( assert ) {
 			var $datepicker = $( html ).datepicker();
 			var newDate = new Date( 1987, 2, 31 );
 			var datepickerDate;
 
 			$datepicker.datepicker( "setDate", newDate );
+			datepickerDate = $datepicker.datepicker( "getDate" );
+
+			assert.equal( datepickerDate.getTime(), newDate.getTime(), "setDate method works" );
+		} );
+
+		QUnit.test( "should set new date using setDate method passing a ISO string", function( assert ) {
+			var $datepicker = $( html ).datepicker();
+			var dateString = '2015-05-29T04:00:00.000Z';
+			var newDate = new Date(dateString);
+			var datepickerDate;
+
+			$datepicker.datepicker( "setDate", dateString);
 			datepickerDate = $datepicker.datepicker( "getDate" );
 
 			assert.equal( datepickerDate.getTime(), newDate.getTime(), "setDate method works" );

--- a/test/datepicker-test.js
+++ b/test/datepicker-test.js
@@ -75,12 +75,24 @@ define(function( require ) {
 		assert.equal( date1, date2, "getValue alias matches getDate" );
 	} );
 
-	QUnit.test( "should set new date using setDate method", function( assert ) {
+	QUnit.test( "should set new date using setDate method passing a Date object", function( assert ) {
 		var $datepicker = $( html ).datepicker();
 		var newDate = new Date( 1987, 2, 31 );
 		var datepickerDate;
 
 		$datepicker.datepicker( "setDate", newDate );
+		datepickerDate = $datepicker.datepicker( "getDate" );
+
+		assert.equal( datepickerDate.getTime(), newDate.getTime(), "setDate method works" );
+	} );
+
+	QUnit.test( "should set new date using setDate method passing a ISO string", function( assert ) {
+		var $datepicker = $( html ).datepicker();
+		var dateString = '2015-05-29T04:00:00.000Z';
+		var newDate = new Date(dateString);
+		var datepickerDate;
+
+		$datepicker.datepicker( "setDate", dateString);
 		datepickerDate = $datepicker.datepicker( "getDate" );
 
 		assert.equal( datepickerDate.getTime(), newDate.getTime(), "setDate method works" );


### PR DESCRIPTION
fixes #1906 

Code made two attempts to parse but passed the failed result from the first attempt to the second attempt instead of the raw date string.


