### PR TITLE
travis config needs java 8 for html lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
 - 6.8.1
 sudo: false
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 install:
 - time npm install
 - time ./node_modules/bower/bin/bower update


### PR DESCRIPTION
travis fails on html lint requiring java 8
![image](https://cloud.githubusercontent.com/assets/347227/21819183/b1da8852-d738-11e6-8e50-6b28e8a6cc29.png)
