### PR TITLE
Revert "Update grunt-html to version 8.1.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-qunit": "1.2.0",
     "grunt-contrib-uglify": "2.0.0",
     "grunt-contrib-watch": "1.0.0",
-    "grunt-html": "8.1.0",
+    "grunt-html": "5.0.1",
     "grunt-jsbeautifier": "0.2.13",
     "grunt-prompt": "1.3.3",
     "grunt-saucelabs": "9.0.0",


### PR DESCRIPTION
Reverts ExactTarget/fuelux#1901

miss understood travis error. problem exists because of old java sdk. updating before merging #1917 and grunt-html 8.2.0