### PR TITLE
Add background size to infinite scroll loader

### DIFF
--- a/less/infinite-scroll.less
+++ b/less/infinite-scroll.less
@@ -25,6 +25,7 @@
 				height: 32px;
 				margin: 0 auto;
 				width: 32px;
+				background-size: contain;
 			}
 		}
 	}


### PR DESCRIPTION
This will allow the infinite scroll loader to look correct. Screenshots provided.

**Before**
<img width="460" alt="screen shot 2017-01-18 at 12 04 06" src="https://cloud.githubusercontent.com/assets/521270/22063321/26d06c9c-dd76-11e6-82dc-15566d5b4572.png">

**After**
<img width="451" alt="screen shot 2017-01-18 at 12 03 05" src="https://cloud.githubusercontent.com/assets/521270/22063335/2f086cf2-dd76-11e6-8c09-5de444961411.png">



 

