### PR TITLE
gh-pages/update placard cancelled events. fixes #1931

### DIFF
--- a/_includes/js/placard.html
+++ b/_includes/js/placard.html
@@ -216,7 +216,7 @@
           <td>Fires when the user indicates the desire to 'accept' changes. This event fires after the <code>onAccept</code> function, if defined.</td>
         </tr>
         <tr>
-          <td>canceled.fu.placard</td>
+          <td>cancelled.fu.placard</td>
           <td>Fires when the user indicates the desire to 'cancel' changes. This event fires after the <code>onCancel</code> function, if defined.</td>
         </tr>
         <tr>


### PR DESCRIPTION
Docs update. Correct to event actually fired when cancel is hit on placard

 

