### PR TITLE
Set height properly on repeater resize

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -698,6 +698,23 @@
 			var viewTypeObj = {};
 			var height;
 			var viewportMargins;
+			var scrubbedElements = [];
+			var previousProperties = [];
+			var $hiddenElements = this.$element.parentsUntil(':visible').addBack();
+			var currentHiddenElement;
+			var currentElementIndex = 0;
+
+			// Set parents to 'display:block' until repeater is visible again
+			while (currentElementIndex < $hiddenElements.length && this.$element.is(':hidden')) {
+				currentHiddenElement = $hiddenElements[currentElementIndex];
+				// Only set display property on elements that are explicitly hidden (i.e. do not inherit it from their parent)
+				if ($(currentHiddenElement).is(':hidden')) {
+					previousProperties.push(currentHiddenElement.style['display']);
+					currentHiddenElement.style['display'] = 'block';
+					scrubbedElements.push(currentHiddenElement);
+				}
+				currentElementIndex++;
+			}
 
 			if (this.viewType) {
 				viewTypeObj = $.fn.repeater.viewTypes[this.viewType] || {};
@@ -728,6 +745,10 @@
 					width: this.$element.outerWidth()
 				});
 			}
+
+			scrubbedElements.forEach(function (element, i) {
+				element.style['display'] = previousProperties[i];
+			});
 		},
 
 		// e.g. "Rows" or "Thumbnails"

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -425,6 +425,31 @@ define( function ( require ) {
 		} );
 	} );
 
+	QUnit.test( 'resize should set height correctly when called inside hidden DOM object', function resize (assert) {
+		var ready = assert.async();
+		var $hiddenDiv = $('' +
+			'<div style="display:none">' +
+			'	<div class="repeaterDiv"></div>' +
+			'</div>');
+		$('.fuelux').append($hiddenDiv);
+		$hiddenDiv.find('.repeaterDiv').append(this.$markup);
+		var $repeater = $( $hiddenDiv.find('.repeater'));
+		var $repeaterViewport = $( $repeater.find('.repeater-viewport'));
+
+		$repeater.repeater( {
+			dataSource: function dataSource( options, callback ) {
+				callback( { smileys: [ ':)', ':)', ':)' ] } );
+				$hiddenDiv.show();
+				$repeaterViewport.css('min-height', 0);
+				assert.notEqual($repeaterViewport.height(), 0, 'height set to non-zero value on resize');
+				$hiddenDiv.remove();
+				ready();
+			},
+			staticHeight:true
+		} );
+
+	} );
+
 	QUnit.test( 'should destroy control', function destroy( assert ) {
 		var ready = assert.async();
 		var $repeater = $( this.$markup );


### PR DESCRIPTION
Fixes Issue #1944 
This fix resolves the issue of the fuel repeater incorrectly calculating its height whenever the resize function is called when the repeater is not visible, specifically when inside of a parent element which is not visible. The fix relies upon the single threaded nature of javascript to temporarily show the repeater, calculate its height, and then hide the repeater all before the UI thread re-obtains control to display the changes. 

Alternative solutions such as making the items position: absolute and display:hidden were also considered but ultimately resulted in inaccurate height calculations in certain circumstances with no real benefit, since the UI thread does not display the changes regardless.
