### PR TITLE
Make spinbox trigger changed after setValue

### DIFF
--- a/js/spinbox.js
+++ b/js/spinbox.js
@@ -167,11 +167,11 @@
 		},
 
 		render: function render() {
-			this.setValue(this.getDisplayValue());
+			this._setValue(this.getDisplayValue());
 		},
 
 		change: function change() {
-			this.setValue(this.getDisplayValue());
+			this._setValue(this.getDisplayValue());
 
 			this.triggerChangedEvent();
 		},
@@ -222,7 +222,7 @@
 
 		step: function step(isIncrease) {
 			//refresh value from display before trying to increment in case they have just been typing before clicking the nubbins
-			this.setValue(this.getDisplayValue());
+			this._setValue(this.getDisplayValue());
 			var newVal;
 
 			if (isIncrease) {
@@ -233,7 +233,7 @@
 
 			newVal = newVal.toFixed(5);
 
-			this.setValue(newVal + this.unit);
+			this._setValue(newVal + this.unit);
 		},
 
 		getDisplayValue: function getDisplayValue() {
@@ -255,6 +255,10 @@
 		},
 
 		setValue: function setValue(val) {
+			return this._setValue(val, true);
+		},
+
+		_setValue: function _setValue(val, shouldSetLastValue) {
 			//remove any i18n on the number
 			if (this.options.decimalMark !== '.') {
 				val = this.parseInput(val);
@@ -271,7 +275,7 @@
 
 			//make sure we are dealing with a number
 			if (isNaN(intVal) && !isFinite(intVal)) {
-				return this.setValue(this.options.value);
+				return this._setValue(this.options.value, shouldSetLastValue);
 			}
 
 			//conform
@@ -289,6 +293,10 @@
 
 			//display number
 			this.setDisplayValue(val);
+
+			if (shouldSetLastValue) {
+				this.lastValue = val;
+			}
 
 			return this;
 		},

--- a/test/spinbox-test.js
+++ b/test/spinbox-test.js
@@ -285,6 +285,21 @@ define( function ( require ) {
 
 	} );
 
+	QUnit.test('spinbox should trigger change after using setValue', function (assert) {
+		var $spinbox = $(html).find('#MySpinboxDecimal').spinbox({
+			value: '1'
+		});
+
+		$spinbox.spinbox('setValue', '2');
+
+		$spinbox.on('changed.fu.spinbox', function () {
+			assert.ok(true, 'spinbox triggers changed after input' );
+		});
+
+		$spinbox.find('.spinbox-input').val(1);
+		$spinbox.find('.spinbox-input').focusout();
+	});
+
 	QUnit.test( "should destroy control", function( assert ) {
 		var $el = $( html ).find( "#MySpinbox" );
 


### PR DESCRIPTION
After programmatically setting the value of the spinbox, the previous
value would be retained in the lastValue property of the control,
causing the "changed" event not to get triggered if the user were to
enter the previous value again. To avoid this, the current setValue
method was converted into a private method with an additional parameter
to set the last value, and the public method will wrap this and pass
that parameter, while internal uses of the method will use the private
method to avoid other side effects.

Fixes #1950
