### PR TITLE
Repair travis qunit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "jquery": null,
     "jquery-1.9.1": "jquery#1.9.1",
-    "qunit": "2.x",
+    "qunit": "2.3.0",
     "requirejs-text": "2.x",
     "underscore": "1.x",
     "blanket": "1.x",

--- a/test/repeater-test.js
+++ b/test/repeater-test.js
@@ -380,14 +380,12 @@ define( function ( require ) {
 	QUnit.test( 'rendered.fu.repeater callback should receive correct data when called by renderItems function', function dataSourceCallbackTest( assert ) {
 		var ready = assert.async();
 		var $repeater = $( this.$markup );
-		var count = 0;
 		$repeater.on( 'rendered.fu.repeater', function rendered ( e, state ) {
-			count++;
+			// rendered is triggered on `this.$search` and `this.$element` in repeater.js
+			if ( e.target.id === $repeater.attr('id') ) {
+				assert.ok( state.data, 'data object exists' );
+				assert.equal( state.data.myVar, 'passalong', 'data returned from datasource was passed along' );
 
-			assert.ok( state.data, 'data object exists' );
-			assert.equal( state.data.myVar, 'passalong', 'data returned from datasource was passed along' );
-
-			if ( count === 2 ) {
 				ready();
 			}
 		} );


### PR DESCRIPTION
Travis ci failing because of something introduced in qunit 2.3.1. 
https://github.com/qunitjs/qunit/blob/master/History.md#231--2017-04-10

Pinning until more research can be done and PRs are unblocked.

To see error pull down master and do a fresh bower install.
```
git fetch upstream;
git checkout master;
git reset --hard upstream/master;
rm -rf bower_components;
bower install;
grunt travisci;
```
this will fail on 
![image](https://cloud.githubusercontent.com/assets/347227/25196160/d0ea20f4-250d-11e7-9e70-05493cb4e3f8.png)
like #1959 https://travis-ci.org/ExactTarget/fuelux/builds/222159155

To see fix pull down the branch and do a fresh bower install.
```
git fetch swilliamset;
git checkout -b repair-travis-qunit;
git reset --hard swilliamset/repair-travis-qunit;
rm -rf bower_components;
bower install;
grunt travisci;
```
