### PR TITLE
Fix keydown event listener scope in tree

### DIFF
--- a/js/tree.js
+++ b/js/tree.js
@@ -71,6 +71,13 @@
 		});
 
 		this.$element.on('keydown', function processKeypress (e) {
+			var target = $(e.target);
+			// Only listen to keydown events on these classes,
+			// otherwise the events will not propagate to the proper children
+			if (!target.hasClass('tree-branch') && !target.hasClass('tree-item')) {
+				return;
+			}
+
 			return navigateTree($(this), e);
 		});
 

--- a/test/tree-tests/space-key-module.js
+++ b/test/tree-tests/space-key-module.js
@@ -15,5 +15,34 @@ define(function keyboardNavigationModuleFactory (require) {
 				// Skipped due to time constraints. If you touch this part of the tree, please complete this test
 			});
 		});
+
+		QUnit.module( 'should not respond to space key', {}, function testSpaceKeyPresses () {
+			QUnit.test('when focus is on a child element', function loadTree (assert) {
+				assert.expect(1);
+
+				this.$tree.on('initialized.fu.tree', function triggerDownArrow () {
+					var $initialBranch = $(this.$tree.find('li:not(".hidden")').get(1));
+
+					$initialBranch.attr('tabindex', 0);
+					$initialBranch.focus();
+
+					this.$tree.on('keyboardNavigated.fu.tree', function testDownArrowResult () {
+						assert.notOk(true, 'the keyboardNavigated event should not be triggered');
+					});
+
+					assert.equal($(document.activeElement).attr('id'), $initialBranch.attr('id'), 'initial branch has focus');
+
+					var $popoverDiv = $('<div class="popover" />');
+					$initialBranch.append($popoverDiv);
+
+					var pressSpaceKey = this.getKeyDown('down', $popoverDiv);
+					$popoverDiv.trigger(pressSpaceKey);
+				}.bind(this));
+
+				this.$tree.tree({
+					dataSource: this.dataSource
+				});
+			});
+		});
 	};
 });


### PR DESCRIPTION
fixes https://github.com/ExactTarget/fuelux/issues/2011

This adds a unit test demonstrates what happens when a child element is added along with the fix, which limits the scope of the keydown event consumption. 