### PR TITLE
Points main property in package.json to correct file

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "type": "BSD-3-Clause",
     "url": "https://github.com/ExactTarget/fuelux/blob/master/LICENSE"
   },
-  "main": "./dist/js/npm",
+  "main": "./js/npm",
   "name": "fuelux",
   "private": false,
   "repository": {


### PR DESCRIPTION
When requiring FuelUX via Node, it is looking at the main file listed in package.json.  This looks like it was inspired by Bootstrap which has an npm file in dist, however in Fuel it is not.  The path to the npm file was updated to point to the correct file.