### PR TITLE
Prevents pillbox double insert in IE 11/Edge 14

### DIFF
--- a/js/pillbox.js
+++ b/js/pillbox.js
@@ -380,7 +380,7 @@
 				// ignore comma and make sure text that has been entered (protects against " ,". https://github.com/ExactTarget/fuelux/issues/593), unless allowEmptyPills is true.
 				if (text.replace(/[ ]*\,[ ]*/, '').match(/\S/) || (this.options.allowEmptyPills && text.length)) {
 					this._closeSuggestions();
-					this.$addItem.hide().val('');
+					this.$addItem.val('').hide();
 
 					if (attr) {
 						this.addItems({


### PR DESCRIPTION
Fixes #2022 

In IE11, the hide of $addItem causes on focusout event to be triggered. With the checks in this function it determines that:
A) If a focusout event has occurred
and B) There is text in the input box
then it should add a pillbox. Since the hide triggers a focusout event in IE11, entering text and pressing enter will get you to this line. It will then hide the item, triggering a blur event. Since the item still has text, the blur event will add it to the pillbox, then the enter event will also add it to the pillbox causing it to be double entered.

Setting the value to blank before hiding causes condition B to be invalidated whenever the function is called for the focusout event.

NOTE: No unit test was written for this as fuelux does not appear to contain a spy library such as sinon to evaluate that the val function is called before the hide function. Similarly, the behaviour in IE11 cannot be validated via unit test.



 

