### PR TITLE
Uses correct element to initialize checkbox on mouseover (fixes #2007)

### DIFF
--- a/js/checkbox.js
+++ b/js/checkbox.js
@@ -204,7 +204,7 @@
 	// DATA-API
 
 	$(document).on('mouseover.fu.checkbox.data-api', '[data-initialize=checkbox]', function initializeCheckboxes (e) {
-		var $control = $(e.target);
+		var $control = $(this);
 		if (!$control.data('fu.checkbox')) {
 			$control.checkbox($control.data());
 		}


### PR DESCRIPTION
If there is markup in the label, the target for the event can be a child of the label element rather than the label element itself.

 

