### PR TITLE
Infinite Scroll: Keep fetching until repeater needs to scroll

### DIFF
--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -84,7 +84,7 @@
 		getPercentage: function () {
 			var height = (this.$element.css('box-sizing') === 'border-box') ? this.$element.outerHeight() : this.$element.height();
 			var scrollHeight = this.$element.get(0).scrollHeight;
-			return (scrollHeight > height) ? ((height / (scrollHeight - this.curScrollTop)) * 100) : 0;
+			return (height / (scrollHeight - this.curScrollTop)) * 100;
 		},
 
 		fetchData: function (force) {

--- a/js/repeater.js
+++ b/js/repeater.js
@@ -485,6 +485,8 @@
 
 			if (data.end === true || (this.currentPage + 1) >= pages) {
 				this.infiniteScrollingCont.infinitescroll('end', end);
+			} else {
+				this.infiniteScrollingCont.infinitescroll('onScroll');
 			}
 		},
 

--- a/test/infinite-scroll-test.js
+++ b/test/infinite-scroll-test.js
@@ -69,6 +69,24 @@ define( function infiniteScrollTest ( require ) {
 		$infiniteScroll.scrollTop( ( $infiniteScroll.get( 0 ).scrollHeight - ( $infiniteScroll.height() / ( percent / 100 ) ) ) + 1 );
 	} );
 
+	QUnit.test( 'should fetch on initial load without any content', function autoLoadTest ( assert ) {
+		var ready = assert.async();
+		var $infiniteScroll = $( html );
+		var scrollHeight;
+
+		$( 'body' ).append( $infiniteScroll );
+		$infiniteScroll.infinitescroll( {
+			dataSource: function dataSource ( helpers, callback ) {
+				assert.ok( true, 'dataSource function called upon initial load' );
+				assert.ok( ( helpers.percentage && helpers.scrollTop === 0 ), 'appropriate helpers passed to dataSource function' );
+				assert.ok( typeof callback === 'function', 'appropriate callback passed to dataSource function' );
+
+				$infiniteScroll.remove();
+				ready();
+			}
+		} );
+	} );
+
 	QUnit.test( 'destroy control', function destroyControl ( assert ) {
 		var ready = assert.async();
 		var $infiniteScroll = $( html );


### PR DESCRIPTION
Fixes #1963 

When using the repeater with infinite scrolling, the repeater could get into a bad state if the initial load does not load enough items to make the repeater scrollable. When the repeater is not scrollable, no more content can be loaded. This PR fixes that by doing two things. First, onScroll now returns 100% scrolled when the repeater does not have a scroll bar. Second, after the content is rendered, onScroll is triggered, which will recursively trigger a fetch until either the repeater is scrollable, or all of the data has been fetched.

@swilliamset Could you look at this and see if it would fix your use case for the infinite loader?
@interactivellama 