### PR TITLE
Fix an infinite scroll bug

### DIFF
--- a/js/repeater.js
+++ b/js/repeater.js
@@ -483,10 +483,12 @@
 
 			this.currentPage = (page !== undefined) ? page : NaN;
 
-			if (data.end === true || (this.currentPage + 1) >= pages) {
-				this.infiniteScrollingCont.infinitescroll('end', end);
-			} else {
-				this.infiniteScrollingCont.infinitescroll('onScroll');
+			if (this.infiniteScrollingCont) {
+				if (data.end === true || (this.currentPage + 1) >= pages) {
+					this.infiniteScrollingCont.infinitescroll('end', end);
+				} else {
+					this.infiniteScrollingCont.infinitescroll('onScroll');
+				}
 			}
 		},
 


### PR DESCRIPTION
A bug with the infinite scrolling could appear when the repeater was initialized but it has not been inserted into the DOM.



 

