### PR TITLE
Prevent infinite scroll from fetching all pages

### DIFF
--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -84,6 +84,11 @@
 		getPercentage: function () {
 			var height = (this.$element.css('box-sizing') === 'border-box') ? this.$element.outerHeight() : this.$element.height();
 			var scrollHeight = this.$element.get(0).scrollHeight;
+			// If we cannot compute the height, then we end up fetching all pages (ends up #/0 = Infinity).
+			// This can happen if the repeater is loaded, but is not in the dom
+			if (scrollHeight === 0 || scrollHeight - this.curScrollTop === 0) {
+				return 0;
+			}
 			return (height / (scrollHeight - this.curScrollTop)) * 100;
 		},
 


### PR DESCRIPTION
Infinite scroll could sometimes fetch all pages on initialization if the
repeater was not attached to the DOM.