### PR TITLE
W-5234018 - Fix XSS vulnerability in email admin screen

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "registry": "https://registry.bower.io"
+}

--- a/js/tree.js
+++ b/js/tree.js
@@ -159,7 +159,7 @@
 						.removeClass('hide hidden')// jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 						.removeData('template')
 						.removeAttr('data-template');
-					$entity.find('.tree-' + nodeType + '-name > .tree-label').text(treeNode.text || treeNode.name);
+					$entity.find('.tree-' + nodeType + '-name > .tree-label')[self.options.html ? 'html' : 'text'](treeNode.text || treeNode.name);
 					$entity.data(treeNode);
 
 

--- a/js/tree.js
+++ b/js/tree.js
@@ -159,7 +159,7 @@
 						.removeClass('hide hidden')// jQuery deprecated hide in 3.0. Use hidden instead. Leaving hide here to support previous markup
 						.removeData('template')
 						.removeAttr('data-template');
-					$entity.find('.tree-' + nodeType + '-name > .tree-label').html(treeNode.text || treeNode.name);
+					$entity.find('.tree-' + nodeType + '-name > .tree-label').text(treeNode.text || treeNode.name);
 					$entity.data(treeNode);
 
 


### PR DESCRIPTION
This change fixes a P1 security ticket (W-5234018). The issue is that XSS is firing in the DE selector tree in the From Address Management page. The best solution to this problem is to render the name of the the DEs as text rather than as html. As a result, this change needs to be made to change one .html call to a .text call in tree.js.

Here is a link to the P1 sec ticket for reference:
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005FEeWIAW/view

 

