### PR TITLE
Fix reporting of percentage for infinite scroll

### DIFF
--- a/js/infinite-scroll.js
+++ b/js/infinite-scroll.js
@@ -86,7 +86,7 @@
 			var scrollHeight = this.$element.get(0).scrollHeight;
 			// If we cannot compute the height, then we end up fetching all pages (ends up #/0 = Infinity).
 			// This can happen if the repeater is loaded, but is not in the dom
-			if (scrollHeight === 0 || scrollHeight - this.curScrollTop === 0) {
+			if (scrollHeight === 0 || scrollHeight - this.curScrollTop === 0 || height === scrollHeight) {
 				return 0;
 			}
 			return (height / (scrollHeight - this.curScrollTop)) * 100;


### PR DESCRIPTION
This is a fix for the repeater control when used with the thumbnail extension. In some cases the infinite scroll control would fetch extra pages.